### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/download-citation/2018-12-13-22-18-39.ris
+++ b/download-citation/2018-12-13-22-18-39.ris
@@ -11,7 +11,7 @@ PB  - Springer US
 SN  - 1573-482X
 DO  - 10.1007/s10854-016-6044-6
 M3  - 10.1007/s10854-016-6044-6
-UR  - http://dx.doi.org/10.1007/s10854-016-6044-6
+UR  - https://doi.org/10.1007/s10854-016-6044-6
 N2  - In this paper, user-defined copper conductive patterns were successfully fabricated via electroless deposition onto paper substrate by using a four-step treatment process. The pristine paper samples are first dipped in 3-aminopropyltrimethoxysilane (APTMS) solution to form a uniform layer for the subsequent absorption of gold nanoparticles. Then the paper samples were wax patterned and immersed in gold nanoparticles solution in preparation for the next step electroless deposition. Herein, wax pattern was achieved via a stylus printer to print desired stencil dot matrix, which acted as hydrophobic channels, onto the paper substrate. FT-IR measurement, ultrasonic washing test and Scotch®-tape test were utilized to investigate the interaction mechanism between APTMS molecules and paper substrate. Contact angle measurement demonstrated that the hydrophobic surface of wax patterned paper. SEM images showed that the thickness of copper conductive patterns was estimated to be 2.44 μm, which was corresponding well with Surface Profiler measurement. X-ray diffraction analysis showed that the copper films deposited on paper substrate has a structure with Cu (1 1 1) preferred orientation and the resistivity of Cu patterns measured by a digital four-point probe was 6.8 µΩ cm, which was 4.2 times of the bulk Cu. Notably, only one cycle of printing wax on paper substrate could successfully regulate the deposition area of Cu films. Those above advantages make this method a promising candidate for applications in constructing functional flexible electronic devices.
 A1  - u, L e i   H o
 A1  - o, H a n g   Z h a
@@ -32,7 +32,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2005-4602
 DO  - 10.1007/s12541-015-0283-y
 M3  - 10.1007/s12541-015-0283-y
-UR  - http://dx.doi.org/10.1007/s12541-015-0283-y
+UR  - https://doi.org/10.1007/s12541-015-0283-y
 N2  - In this paper, user-defined copper conductive patterns were successfully fabricated via electroless deposition onto paper substrate by using a four-step treatment process. The pristine paper samples are first dipped in 3-aminopropyltrimethoxysilane (APTMS) solution to form a uniform layer for the subsequent absorption of gold nanoparticles. Then the paper samples were wax patterned and immersed in gold nanoparticles solution in preparation for the next step electroless deposition. Herein, wax pattern was achieved via a stylus printer to print desired stencil dot matrix, which acted as hydrophobic channels, onto the paper substrate. FT-IR measurement, ultrasonic washing test and Scotch®-tape test were utilized to investigate the interaction mechanism between APTMS molecules and paper substrate. Contact angle measurement demonstrated that the hydrophobic surface of wax patterned paper. SEM images showed that the thickness of copper conductive patterns was estimated to be 2.44 μm, which was corresponding well with Surface Profiler measurement. X-ray diffraction analysis showed that the copper films deposited on paper substrate has a structure with Cu (1 1 1) preferred orientation and the resistivity of Cu patterns measured by a digital four-point probe was 6.8 µΩ cm, which was 4.2 times of the bulk Cu. Notably, only one cycle of printing wax on paper substrate could successfully regulate the deposition area of Cu films. Those above advantages make this method a promising candidate for applications in constructing functional flexible electronic devices.
 A1  - i, E u n   K u k   C h o
 A1  - k, J a n g h o o n   P a r
@@ -54,7 +54,7 @@ PB  - SP Science China Press
 SN  - 1861-9541
 DO  - 10.1007/s11434-010-3251-y
 M3  - 10.1007/s11434-010-3251-y
-UR  - http://dx.doi.org/10.1007/s11434-010-3251-y
+UR  - https://doi.org/10.1007/s11434-010-3251-y
 N2  - In this paper, user-defined copper conductive patterns were successfully fabricated via electroless deposition onto paper substrate by using a four-step treatment process. The pristine paper samples are first dipped in 3-aminopropyltrimethoxysilane (APTMS) solution to form a uniform layer for the subsequent absorption of gold nanoparticles. Then the paper samples were wax patterned and immersed in gold nanoparticles solution in preparation for the next step electroless deposition. Herein, wax pattern was achieved via a stylus printer to print desired stencil dot matrix, which acted as hydrophobic channels, onto the paper substrate. FT-IR measurement, ultrasonic washing test and Scotch®-tape test were utilized to investigate the interaction mechanism between APTMS molecules and paper substrate. Contact angle measurement demonstrated that the hydrophobic surface of wax patterned paper. SEM images showed that the thickness of copper conductive patterns was estimated to be 2.44 μm, which was corresponding well with Surface Profiler measurement. X-ray diffraction analysis showed that the copper films deposited on paper substrate has a structure with Cu (1 1 1) preferred orientation and the resistivity of Cu patterns measured by a digital four-point probe was 6.8 µΩ cm, which was 4.2 times of the bulk Cu. Notably, only one cycle of printing wax on paper substrate could successfully regulate the deposition area of Cu films. Those above advantages make this method a promising candidate for applications in constructing functional flexible electronic devices.
 A1  - n, Z h o u P i n g   Y i
 A1  - g, Y o n g A n   H u a n
@@ -77,7 +77,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 2150-5551
 DO  - 10.1007/s40820-017-0139-3
 M3  - 10.1007/s40820-017-0139-3
-UR  - http://dx.doi.org/10.1007/s40820-017-0139-3
+UR  - https://doi.org/10.1007/s40820-017-0139-3
 N2  - In this paper, user-defined copper conductive patterns were successfully fabricated via electroless deposition onto paper substrate by using a four-step treatment process. The pristine paper samples are first dipped in 3-aminopropyltrimethoxysilane (APTMS) solution to form a uniform layer for the subsequent absorption of gold nanoparticles. Then the paper samples were wax patterned and immersed in gold nanoparticles solution in preparation for the next step electroless deposition. Herein, wax pattern was achieved via a stylus printer to print desired stencil dot matrix, which acted as hydrophobic channels, onto the paper substrate. FT-IR measurement, ultrasonic washing test and Scotch®-tape test were utilized to investigate the interaction mechanism between APTMS molecules and paper substrate. Contact angle measurement demonstrated that the hydrophobic surface of wax patterned paper. SEM images showed that the thickness of copper conductive patterns was estimated to be 2.44 μm, which was corresponding well with Surface Profiler measurement. X-ray diffraction analysis showed that the copper films deposited on paper substrate has a structure with Cu (1 1 1) preferred orientation and the resistivity of Cu patterns measured by a digital four-point probe was 6.8 µΩ cm, which was 4.2 times of the bulk Cu. Notably, only one cycle of printing wax on paper substrate could successfully regulate the deposition area of Cu films. Those above advantages make this method a promising candidate for applications in constructing functional flexible electronic devices.
 A1  - i, S h i   B a
 A1  - g, S h i g a n g   Z h a n
@@ -102,7 +102,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2005-4602
 DO  - 10.1007/s12541-014-0630-4
 M3  - 10.1007/s12541-014-0630-4
-UR  - http://dx.doi.org/10.1007/s12541-014-0630-4
+UR  - https://doi.org/10.1007/s12541-014-0630-4
 N2  - In this paper, user-defined copper conductive patterns were successfully fabricated via electroless deposition onto paper substrate by using a four-step treatment process. The pristine paper samples are first dipped in 3-aminopropyltrimethoxysilane (APTMS) solution to form a uniform layer for the subsequent absorption of gold nanoparticles. Then the paper samples were wax patterned and immersed in gold nanoparticles solution in preparation for the next step electroless deposition. Herein, wax pattern was achieved via a stylus printer to print desired stencil dot matrix, which acted as hydrophobic channels, onto the paper substrate. FT-IR measurement, ultrasonic washing test and Scotch®-tape test were utilized to investigate the interaction mechanism between APTMS molecules and paper substrate. Contact angle measurement demonstrated that the hydrophobic surface of wax patterned paper. SEM images showed that the thickness of copper conductive patterns was estimated to be 2.44 μm, which was corresponding well with Surface Profiler measurement. X-ray diffraction analysis showed that the copper films deposited on paper substrate has a structure with Cu (1 1 1) preferred orientation and the resistivity of Cu patterns measured by a digital four-point probe was 6.8 µΩ cm, which was 4.2 times of the bulk Cu. Notably, only one cycle of printing wax on paper substrate could successfully regulate the deposition area of Cu films. Those above advantages make this method a promising candidate for applications in constructing functional flexible electronic devices.
 A1  - a, T a k a h i r o   Y a m a s h i t
 A1  - o, K e n s a k u   Y o s h i n
@@ -123,7 +123,7 @@ PB  - Springer US
 SN  - 1573-482X
 DO  - 10.1007/s10854-016-4734-8
 M3  - 10.1007/s10854-016-4734-8
-UR  - http://dx.doi.org/10.1007/s10854-016-4734-8
+UR  - https://doi.org/10.1007/s10854-016-4734-8
 N2  - We report that both low electric resistivity and strong adhesion to polyimide film were attained for a conductive Cu film prepared by low-temperature sintering of 2-amino-1-butanol-protected Cu nanoparticles (AB-Cu NPs) with an average size of 4.4 nm. The sintering temperature of 60 °C for the AB-Cu NPs is the lowest ever reported for Cu NPs. A nanoink comprising these AB-Cu NPs (~35 wt% Cu) produced a conductive Cu film with resistivity of 52 μΩ cm after heating at 150 °C under a nitrogen flow. The adhesion to a polyimide film was compared for films prepared from nanoinks consisting of three different types of alkanol-amine-based Cu NPs: AB-Cu NPs, 1-amino-2-propanol-Cu NPs, and 3-amino-1-propanol-Cu NPs. Only the Cu film prepared from the AB-Cu nanoink established strong adhesion to the substrate without decreasing the electrical conductivity. The adhesiveness is attributed to residual oxidation products after thermal sintering of the Cu nanoinks.
 A1  - a, T o m o n o r i   S u g i y a m
 A1  - i, M a i   K a n z a k
@@ -145,7 +145,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1432-1858
 DO  - 10.1007/s00542-017-3582-7
 M3  - 10.1007/s00542-017-3582-7
-UR  - http://dx.doi.org/10.1007/s00542-017-3582-7
+UR  - https://doi.org/10.1007/s00542-017-3582-7
 N2  - Conventional electronic circuits are made up of electronic components assembled on either rigid substrates like FR4 and ceramic or on flexible substrates based on polymers such as polyimide, PET and PEN foils. The latter type of substrates offers considerable improvements in freedom of motion over its rigid complement although the deformations are still pretty limited due to the inability of common electronic materials, such as metals, to cope with the corresponding deformation. Moreover, the assembly of rigid electronic components can often reduce the circuit’s ability to bend. The current trend towards increased component density on substrates makes the final assembly even less flexible. However, electronic circuits which can fully conform and easily fit in the arbitrary curved surface topologies are of keen interest in various areas of applications. Aside from flexibility, a certain degree of stretching is required for the three-dimensional shaping of electronic systems. Hence, deformability will offer electronics a number of additional features like bendability, conformability shaping and lightweight. Three-dimensional shaped electronics can be obtained either by multi-time (dynamic or elastic) or one time (static, permanent) stretching. In this paper an introduction on deformable and conformable electronics is outlined highlighting the different existing approaches. Some examples of flexible and stretchable electronic applications will be provided in various fields.
 A1  - i, I m e n   C h t i o u
 A1  - t, F r e d e r i c k   B o s s u y
@@ -167,7 +167,7 @@ PB  - Tsinghua Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-011-0123-z
 M3  - 10.1007/s12274-011-0123-z
-UR  - http://dx.doi.org/10.1007/s12274-011-0123-z
+UR  - https://doi.org/10.1007/s12274-011-0123-z
 N2  - Conventional electronic circuits are made up of electronic components assembled on either rigid substrates like FR4 and ceramic or on flexible substrates based on polymers such as polyimide, PET and PEN foils. The latter type of substrates offers considerable improvements in freedom of motion over its rigid complement although the deformations are still pretty limited due to the inability of common electronic materials, such as metals, to cope with the corresponding deformation. Moreover, the assembly of rigid electronic components can often reduce the circuit’s ability to bend. The current trend towards increased component density on substrates makes the final assembly even less flexible. However, electronic circuits which can fully conform and easily fit in the arbitrary curved surface topologies are of keen interest in various areas of applications. Aside from flexibility, a certain degree of stretching is required for the three-dimensional shaping of electronic systems. Hence, deformability will offer electronics a number of additional features like bendability, conformability shaping and lightweight. Three-dimensional shaped electronics can be obtained either by multi-time (dynamic or elastic) or one time (static, permanent) stretching. In this paper an introduction on deformable and conformable electronics is outlined highlighting the different existing approaches. Some examples of flexible and stretchable electronic applications will be provided in various fields.
 A1  - g, L u   H u a n
 A1  - g, Y i   H u a n
@@ -190,7 +190,7 @@ PB  - The Korean Institute of Metals and Materials
 SN  - 2005-4149
 DO  - 10.1007/s12540-018-0155-y
 M3  - 10.1007/s12540-018-0155-y
-UR  - http://dx.doi.org/10.1007/s12540-018-0155-y
+UR  - https://doi.org/10.1007/s12540-018-0155-y
 N2  - The effect that the deformation state exerts on both the electrical and the mechanical degradation of Cu thin film on a flexible PI substrate was investigated via cyclic sliding test. Two opposite types of deformation (tension and compression) were applied to Cu thin film depending on its outward or inward placement in the cyclic sliding test system. During the cyclic sliding test, the change in electrical resistance of the Cu thin films was monitored using a two-point probe method. Systematic surface observation of deformed Cu thin film under the two opposite types of deformation was performed following specific cycles of sliding motion. Surface observation based on field emission scanning electron microscopy and 3D confocal laser scanning microscopy had been done to quantify the evolution of intrusion extrusions and surface roughness on the deformed Cu thin film. The distribution of microcracks significantly depended on the type of stress/strain applied to the Cu thin film on a flexible PI substrate during the cyclic sliding test. Finite element analysis was performed to explain the deformation behavior of the Cu thin film on a flexible PI substrate during the cyclic sliding test.
 A1  - g, A t a n u   B a
 A1  - k, K i - S e o n g   P a r
@@ -211,7 +211,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2198-0810
 DO  - 10.1007/s40684-015-0040-9
 M3  - 10.1007/s40684-015-0040-9
-UR  - http://dx.doi.org/10.1007/s40684-015-0040-9
+UR  - https://doi.org/10.1007/s40684-015-0040-9
 N2  - The effect that the deformation state exerts on both the electrical and the mechanical degradation of Cu thin film on a flexible PI substrate was investigated via cyclic sliding test. Two opposite types of deformation (tension and compression) were applied to Cu thin film depending on its outward or inward placement in the cyclic sliding test system. During the cyclic sliding test, the change in electrical resistance of the Cu thin films was monitored using a two-point probe method. Systematic surface observation of deformed Cu thin film under the two opposite types of deformation was performed following specific cycles of sliding motion. Surface observation based on field emission scanning electron microscopy and 3D confocal laser scanning microscopy had been done to quantify the evolution of intrusion extrusions and surface roughness on the deformed Cu thin film. The distribution of microcracks significantly depended on the type of stress/strain applied to the Cu thin film on a flexible PI substrate during the cyclic sliding test. Finite element analysis was performed to explain the deformation behavior of the Cu thin film on a flexible PI substrate during the cyclic sliding test.
 A1  - u, J u n   H o   Y
 A1  - o, Y o o n s o o   R h
@@ -235,7 +235,7 @@ PB  - Springer US
 SN  - 1543-186X
 DO  - 10.1007/s11664-017-5746-8
 M3  - 10.1007/s11664-017-5746-8
-UR  - http://dx.doi.org/10.1007/s11664-017-5746-8
+UR  - https://doi.org/10.1007/s11664-017-5746-8
 N2  - Chalcopyrite copper indium gallium diselenide Cu(Ga0.3In0.7)Se2 films have been deposited on polyimide (PI) plastic substrate by chemical spray pyrolysis using different substrate temperatures in the range from 350°C to 395°C. The influence of substrate temperature on the structural and optical properties of the CIGS films was studied. High-resolution x-ray diffraction results revealed that the films exhibited chalcopyrite-type structure. The crystallite size of the films increased with increasing substrate temperature, as did their root-mean-square surface roughness. Optical transmission measurements by ultraviolet–visible (UV–Vis) spectrophotometer showed that the optical bandgap decreased from 1.28 eV to 1.16 eV as the substrate temperature was increased. This variation of the crystallite size and energy bandgap with substrate temperature makes such films a promising candidate for application in optoelectronic devices such as photoconductors and solar cells.
 A1  - j, M .   G .   F a r a
 A1  - n, M .   Z .   P a k h u r u d d i
@@ -256,7 +256,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 2150-5551
 DO  - 10.1007/s40820-016-0106-4
 M3  - 10.1007/s40820-016-0106-4
-UR  - http://dx.doi.org/10.1007/s40820-016-0106-4
+UR  - https://doi.org/10.1007/s40820-016-0106-4
 N2  - Thin films and thin film devices have a ubiquitous presence in numerous conventional and emerging technologies. This is because of the recent advances in nanotechnology, the development of functional and smart materials, conducting polymers, molecular semiconductors, carbon nanotubes, and graphene, and the employment of unique properties of thin films and ultrathin films, such as high surface area, controlled nanostructure for effective charge transfer, and special physical and chemical properties, to develop new thin film devices. This paper is therefore intended to provide a concise critical review and research directions on most thin film devices, including thin film transistors, data storage memory, solar cells, organic light-emitting diodes, thermoelectric devices, smart materials, sensors, and actuators. The thin film devices may consist of organic, inorganic, and composite thin layers, and share similar functionality, properties, and fabrication routes. Therefore, due to the multidisciplinary nature of thin film devices, knowledge and advances already made in one area may be applicable to other similar areas. Owing to the importance of developing low-cost, scalable, and vacuum-free fabrication routes, this paper focuses on thin film devices that may be processed and deposited from solution.
 A1  - n, M o r t e z a   E s l a m i a
 ER  - 
@@ -275,7 +275,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2005-4602
 DO  - 10.1007/s12541-014-0435-5
 M3  - 10.1007/s12541-014-0435-5
-UR  - http://dx.doi.org/10.1007/s12541-014-0435-5
+UR  - https://doi.org/10.1007/s12541-014-0435-5
 N2  - Thin films and thin film devices have a ubiquitous presence in numerous conventional and emerging technologies. This is because of the recent advances in nanotechnology, the development of functional and smart materials, conducting polymers, molecular semiconductors, carbon nanotubes, and graphene, and the employment of unique properties of thin films and ultrathin films, such as high surface area, controlled nanostructure for effective charge transfer, and special physical and chemical properties, to develop new thin film devices. This paper is therefore intended to provide a concise critical review and research directions on most thin film devices, including thin film transistors, data storage memory, solar cells, organic light-emitting diodes, thermoelectric devices, smart materials, sensors, and actuators. The thin film devices may consist of organic, inorganic, and composite thin layers, and share similar functionality, properties, and fabrication routes. Therefore, due to the multidisciplinary nature of thin film devices, knowledge and advances already made in one area may be applicable to other similar areas. Owing to the importance of developing low-cost, scalable, and vacuum-free fabrication routes, this paper focuses on thin film devices that may be processed and deposited from solution.
 A1  - u, J u n   H o   Y
 A1  - g, K y u n g - T a e   K a n
@@ -298,7 +298,7 @@ PB  - Springer US
 SN  - 1860-2002
 DO  - 10.1007/s11307-013-0703-2
 M3  - 10.1007/s11307-013-0703-2
-UR  - http://dx.doi.org/10.1007/s11307-013-0703-2
+UR  - https://doi.org/10.1007/s11307-013-0703-2
 N2  - Thin films and thin film devices have a ubiquitous presence in numerous conventional and emerging technologies. This is because of the recent advances in nanotechnology, the development of functional and smart materials, conducting polymers, molecular semiconductors, carbon nanotubes, and graphene, and the employment of unique properties of thin films and ultrathin films, such as high surface area, controlled nanostructure for effective charge transfer, and special physical and chemical properties, to develop new thin film devices. This paper is therefore intended to provide a concise critical review and research directions on most thin film devices, including thin film transistors, data storage memory, solar cells, organic light-emitting diodes, thermoelectric devices, smart materials, sensors, and actuators. The thin film devices may consist of organic, inorganic, and composite thin layers, and share similar functionality, properties, and fabrication routes. Therefore, due to the multidisciplinary nature of thin film devices, knowledge and advances already made in one area may be applicable to other similar areas. Owing to the importance of developing low-cost, scalable, and vacuum-free fabrication routes, this paper focuses on thin film devices that may be processed and deposited from solution.
 ER  - 
 
@@ -316,7 +316,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1993-0437
 DO  - 10.1007/s11595-013-0854-7
 M3  - 10.1007/s11595-013-0854-7
-UR  - http://dx.doi.org/10.1007/s11595-013-0854-7
+UR  - https://doi.org/10.1007/s11595-013-0854-7
 N2  - Thin films and thin film devices have a ubiquitous presence in numerous conventional and emerging technologies. This is because of the recent advances in nanotechnology, the development of functional and smart materials, conducting polymers, molecular semiconductors, carbon nanotubes, and graphene, and the employment of unique properties of thin films and ultrathin films, such as high surface area, controlled nanostructure for effective charge transfer, and special physical and chemical properties, to develop new thin film devices. This paper is therefore intended to provide a concise critical review and research directions on most thin film devices, including thin film transistors, data storage memory, solar cells, organic light-emitting diodes, thermoelectric devices, smart materials, sensors, and actuators. The thin film devices may consist of organic, inorganic, and composite thin layers, and share similar functionality, properties, and fabrication routes. Therefore, due to the multidisciplinary nature of thin film devices, knowledge and advances already made in one area may be applicable to other similar areas. Owing to the importance of developing low-cost, scalable, and vacuum-free fabrication routes, this paper focuses on thin film devices that may be processed and deposited from solution.
 A1  - i, S o n g   L
 A1  - u, P e n g   L i
@@ -339,7 +339,7 @@ PB  - SP Higher Education Press
 SN  - 2095-1698
 DO  - 10.1007/s11708-012-0214-x
 M3  - 10.1007/s11708-012-0214-x
-UR  - http://dx.doi.org/10.1007/s11708-012-0214-x
+UR  - https://doi.org/10.1007/s11708-012-0214-x
 N2  - Thin films and thin film devices have a ubiquitous presence in numerous conventional and emerging technologies. This is because of the recent advances in nanotechnology, the development of functional and smart materials, conducting polymers, molecular semiconductors, carbon nanotubes, and graphene, and the employment of unique properties of thin films and ultrathin films, such as high surface area, controlled nanostructure for effective charge transfer, and special physical and chemical properties, to develop new thin film devices. This paper is therefore intended to provide a concise critical review and research directions on most thin film devices, including thin film transistors, data storage memory, solar cells, organic light-emitting diodes, thermoelectric devices, smart materials, sensors, and actuators. The thin film devices may consist of organic, inorganic, and composite thin layers, and share similar functionality, properties, and fabrication routes. Therefore, due to the multidisciplinary nature of thin film devices, knowledge and advances already made in one area may be applicable to other similar areas. Owing to the importance of developing low-cost, scalable, and vacuum-free fabrication routes, this paper focuses on thin film devices that may be processed and deposited from solution.
 A1  - g, Q i n   Z h a n
 A1  - g, Y i   Z h e n
@@ -360,7 +360,7 @@ PB  - Tsinghua Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-011-0160-7
 M3  - 10.1007/s12274-011-0160-7
-UR  - http://dx.doi.org/10.1007/s12274-011-0160-7
+UR  - https://doi.org/10.1007/s12274-011-0160-7
 N2  - Thin films and thin film devices have a ubiquitous presence in numerous conventional and emerging technologies. This is because of the recent advances in nanotechnology, the development of functional and smart materials, conducting polymers, molecular semiconductors, carbon nanotubes, and graphene, and the employment of unique properties of thin films and ultrathin films, such as high surface area, controlled nanostructure for effective charge transfer, and special physical and chemical properties, to develop new thin film devices. This paper is therefore intended to provide a concise critical review and research directions on most thin film devices, including thin film transistors, data storage memory, solar cells, organic light-emitting diodes, thermoelectric devices, smart materials, sensors, and actuators. The thin film devices may consist of organic, inorganic, and composite thin layers, and share similar functionality, properties, and fabrication routes. Therefore, due to the multidisciplinary nature of thin film devices, knowledge and advances already made in one area may be applicable to other similar areas. Owing to the importance of developing low-cost, scalable, and vacuum-free fabrication routes, this paper focuses on thin film devices that may be processed and deposited from solution.
 A1  - u, S h e n g   X
 A1  - g, Z h o n g   L i n   W a n
@@ -380,7 +380,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-017-1942-3
 M3  - 10.1007/s12274-017-1942-3
-UR  - http://dx.doi.org/10.1007/s12274-017-1942-3
+UR  - https://doi.org/10.1007/s12274-017-1942-3
 N2  - Thin films and thin film devices have a ubiquitous presence in numerous conventional and emerging technologies. This is because of the recent advances in nanotechnology, the development of functional and smart materials, conducting polymers, molecular semiconductors, carbon nanotubes, and graphene, and the employment of unique properties of thin films and ultrathin films, such as high surface area, controlled nanostructure for effective charge transfer, and special physical and chemical properties, to develop new thin film devices. This paper is therefore intended to provide a concise critical review and research directions on most thin film devices, including thin film transistors, data storage memory, solar cells, organic light-emitting diodes, thermoelectric devices, smart materials, sensors, and actuators. The thin film devices may consist of organic, inorganic, and composite thin layers, and share similar functionality, properties, and fabrication routes. Therefore, due to the multidisciplinary nature of thin film devices, knowledge and advances already made in one area may be applicable to other similar areas. Owing to the importance of developing low-cost, scalable, and vacuum-free fabrication routes, this paper focuses on thin film devices that may be processed and deposited from solution.
 A1  - u, S h a s h a   Z h o
 A1  - n, L i n   G a
@@ -403,7 +403,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-016-1105-y
 M3  - 10.1007/s12274-016-1105-y
-UR  - http://dx.doi.org/10.1007/s12274-016-1105-y
+UR  - https://doi.org/10.1007/s12274-016-1105-y
 N2  - Thin films and thin film devices have a ubiquitous presence in numerous conventional and emerging technologies. This is because of the recent advances in nanotechnology, the development of functional and smart materials, conducting polymers, molecular semiconductors, carbon nanotubes, and graphene, and the employment of unique properties of thin films and ultrathin films, such as high surface area, controlled nanostructure for effective charge transfer, and special physical and chemical properties, to develop new thin film devices. This paper is therefore intended to provide a concise critical review and research directions on most thin film devices, including thin film transistors, data storage memory, solar cells, organic light-emitting diodes, thermoelectric devices, smart materials, sensors, and actuators. The thin film devices may consist of organic, inorganic, and composite thin layers, and share similar functionality, properties, and fabrication routes. Therefore, due to the multidisciplinary nature of thin film devices, knowledge and advances already made in one area may be applicable to other similar areas. Owing to the importance of developing low-cost, scalable, and vacuum-free fabrication routes, this paper focuses on thin film devices that may be processed and deposited from solution.
 A1  - u, C h o   R o n g   C h
 A1  - e, C h a n g s o o   L e
@@ -425,7 +425,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1433-0768
 DO  - 10.1007/s10008-016-3503-1
 M3  - 10.1007/s10008-016-3503-1
-UR  - http://dx.doi.org/10.1007/s10008-016-3503-1
+UR  - https://doi.org/10.1007/s10008-016-3503-1
 N2  - In this work, the region-selective electroless copper plating on the surface of calcium carbonate (CaCO3)-filled polyehtylene (PE) (CFP) films have been established based on printing primer by screen printing in combination with electroless copper plating. Results showed only the printed areas formed amine groups on the surface of CFP sheets, which served as cores for adsorbing Pd2+ ions. Thus, the pattern on the screen was transferred to the surface of CFP sheets after electroless plating. When the plated time increased from 5 to 120 min, the thickness of plated coating was enhanced from 0.12 to 10 μm and the electrical resistivity was decreased from 12,544 to 0.4 Ω cm. The blown PE films mixed with foam powders and CaCO3 powders could form the coarse surface which can provide a large area for mechanical anchor between the primer and the plated coating, resulting in a better adhesion of the plated coating. In addition, the copper patterning possessed excellent selectivity, compactness, and flexibility. The EMI-SE of plated CFP films is above 30 dB.
 A1  - g, J u n j u n   H u a n
 A1  - n, Z h e n m i n g   C h e
@@ -451,7 +451,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-018-2068-y
 M3  - 10.1007/s12274-018-2068-y
-UR  - http://dx.doi.org/10.1007/s12274-018-2068-y
+UR  - https://doi.org/10.1007/s12274-018-2068-y
 N2  - In this work, the region-selective electroless copper plating on the surface of calcium carbonate (CaCO3)-filled polyehtylene (PE) (CFP) films have been established based on printing primer by screen printing in combination with electroless copper plating. Results showed only the printed areas formed amine groups on the surface of CFP sheets, which served as cores for adsorbing Pd2+ ions. Thus, the pattern on the screen was transferred to the surface of CFP sheets after electroless plating. When the plated time increased from 5 to 120 min, the thickness of plated coating was enhanced from 0.12 to 10 μm and the electrical resistivity was decreased from 12,544 to 0.4 Ω cm. The blown PE films mixed with foam powders and CaCO3 powders could form the coarse surface which can provide a large area for mechanical anchor between the primer and the plated coating, resulting in a better adhesion of the plated coating. In addition, the copper patterning possessed excellent selectivity, compactness, and flexibility. The EMI-SE of plated CFP films is above 30 dB.
 A1  - n, Y u a n j i n g   L i
 A1  - o, Y u a n   G a
@@ -473,7 +473,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-017-1448-z
 M3  - 10.1007/s12274-017-1448-z
-UR  - http://dx.doi.org/10.1007/s12274-017-1448-z
+UR  - https://doi.org/10.1007/s12274-017-1448-z
 N2  - In this work, the region-selective electroless copper plating on the surface of calcium carbonate (CaCO3)-filled polyehtylene (PE) (CFP) films have been established based on printing primer by screen printing in combination with electroless copper plating. Results showed only the printed areas formed amine groups on the surface of CFP sheets, which served as cores for adsorbing Pd2+ ions. Thus, the pattern on the screen was transferred to the surface of CFP sheets after electroless plating. When the plated time increased from 5 to 120 min, the thickness of plated coating was enhanced from 0.12 to 10 μm and the electrical resistivity was decreased from 12,544 to 0.4 Ω cm. The blown PE films mixed with foam powders and CaCO3 powders could form the coarse surface which can provide a large area for mechanical anchor between the primer and the plated coating, resulting in a better adhesion of the plated coating. In addition, the copper patterning possessed excellent selectivity, compactness, and flexibility. The EMI-SE of plated CFP films is above 30 dB.
 A1  - u, L i l i   L i
 A1  - u, Z h i q i a n g   N i
@@ -494,7 +494,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1432-0630
 DO  - 10.1007/s00339-017-0769-9
 M3  - 10.1007/s00339-017-0769-9
-UR  - http://dx.doi.org/10.1007/s00339-017-0769-9
+UR  - https://doi.org/10.1007/s00339-017-0769-9
 N2  - In this work, the region-selective electroless copper plating on the surface of calcium carbonate (CaCO3)-filled polyehtylene (PE) (CFP) films have been established based on printing primer by screen printing in combination with electroless copper plating. Results showed only the printed areas formed amine groups on the surface of CFP sheets, which served as cores for adsorbing Pd2+ ions. Thus, the pattern on the screen was transferred to the surface of CFP sheets after electroless plating. When the plated time increased from 5 to 120 min, the thickness of plated coating was enhanced from 0.12 to 10 μm and the electrical resistivity was decreased from 12,544 to 0.4 Ω cm. The blown PE films mixed with foam powders and CaCO3 powders could form the coarse surface which can provide a large area for mechanical anchor between the primer and the plated coating, resulting in a better adhesion of the plated coating. In addition, the copper patterning possessed excellent selectivity, compactness, and flexibility. The EMI-SE of plated CFP films is above 30 dB.
 A1  - g, S e n - Y e u   Y a n
 A1  - h, J i a n - F u   S h i
@@ -516,7 +516,7 @@ PB  - Springer Netherlands
 SN  - 1572-8838
 DO  - 10.1007/s10800-012-0454-9
 M3  - 10.1007/s10800-012-0454-9
-UR  - http://dx.doi.org/10.1007/s10800-012-0454-9
+UR  - https://doi.org/10.1007/s10800-012-0454-9
 N2  - In this work, the region-selective electroless copper plating on the surface of calcium carbonate (CaCO3)-filled polyehtylene (PE) (CFP) films have been established based on printing primer by screen printing in combination with electroless copper plating. Results showed only the printed areas formed amine groups on the surface of CFP sheets, which served as cores for adsorbing Pd2+ ions. Thus, the pattern on the screen was transferred to the surface of CFP sheets after electroless plating. When the plated time increased from 5 to 120 min, the thickness of plated coating was enhanced from 0.12 to 10 μm and the electrical resistivity was decreased from 12,544 to 0.4 Ω cm. The blown PE films mixed with foam powders and CaCO3 powders could form the coarse surface which can provide a large area for mechanical anchor between the primer and the plated coating, resulting in a better adhesion of the plated coating. In addition, the copper patterning possessed excellent selectivity, compactness, and flexibility. The EMI-SE of plated CFP films is above 30 dB.
 A1  - d, A .   H o v e s t a
 A1  - g, H .   R e n d e r i n
@@ -537,7 +537,7 @@ PB  - Science China Press
 SN  - 2199-4501
 DO  - 10.1007/s40843-016-5091-1
 M3  - 10.1007/s40843-016-5091-1
-UR  - http://dx.doi.org/10.1007/s40843-016-5091-1
+UR  - https://doi.org/10.1007/s40843-016-5091-1
 N2  - In this work, the region-selective electroless copper plating on the surface of calcium carbonate (CaCO3)-filled polyehtylene (PE) (CFP) films have been established based on printing primer by screen printing in combination with electroless copper plating. Results showed only the printed areas formed amine groups on the surface of CFP sheets, which served as cores for adsorbing Pd2+ ions. Thus, the pattern on the screen was transferred to the surface of CFP sheets after electroless plating. When the plated time increased from 5 to 120 min, the thickness of plated coating was enhanced from 0.12 to 10 μm and the electrical resistivity was decreased from 12,544 to 0.4 Ω cm. The blown PE films mixed with foam powders and CaCO3 powders could form the coarse surface which can provide a large area for mechanical anchor between the primer and the plated coating, resulting in a better adhesion of the plated coating. In addition, the copper patterning possessed excellent selectivity, compactness, and flexibility. The EMI-SE of plated CFP films is above 30 dB.
 A1  - n, Y a n   Q i a
 A1  - g, X i n w e n   Z h a n
@@ -562,7 +562,7 @@ PB  - Springer US
 SN  - 1573-482X
 DO  - 10.1007/s10854-018-9567-1
 M3  - 10.1007/s10854-018-9567-1
-UR  - http://dx.doi.org/10.1007/s10854-018-9567-1
+UR  - https://doi.org/10.1007/s10854-018-9567-1
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - v, A m i r   A b i d o
 A1  - m, S u n g j i n   K i
@@ -584,7 +584,7 @@ PB  - Springer US
 SN  - 1860-2002
 DO  - 10.1007/s11307-014-0809-1
 M3  - 10.1007/s11307-014-0809-1
-UR  - http://dx.doi.org/10.1007/s11307-014-0809-1
+UR  - https://doi.org/10.1007/s11307-014-0809-1
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 ER  - 
 
@@ -602,7 +602,7 @@ PB  - Springer London
 SN  - 1433-3015
 DO  - 10.1007/s00170-012-4605-2
 M3  - 10.1007/s00170-012-4605-2
-UR  - http://dx.doi.org/10.1007/s00170-012-4605-2
+UR  - https://doi.org/10.1007/s00170-012-4605-2
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - i, M o h a m m a d   V a e z
 A1  - z, H e r m a n n   S e i t
@@ -623,7 +623,7 @@ PB  - Pleiades Publishing
 SN  - 1608-3172
 DO  - 10.1134/S0020168517110073
 M3  - 10.1134/S0020168517110073
-UR  - http://dx.doi.org/10.1134/S0020168517110073
+UR  - https://doi.org/10.1134/S0020168517110073
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - v, A .   K .   P e t r o
 ER  - 
@@ -642,7 +642,7 @@ PB  - Science China Press
 SN  - 2199-4501
 DO  - 10.1007/s40843-017-9206-4
 M3  - 10.1007/s40843-017-9206-4
-UR  - http://dx.doi.org/10.1007/s40843-017-9206-4
+UR  - https://doi.org/10.1007/s40843-017-9206-4
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - g, L i n   Z h a n
 A1  - u, W e n y a   D
@@ -665,7 +665,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1619-7089
 DO  - 10.1007/s00259-018-4148-3
 M3  - 10.1007/s00259-018-4148-3
-UR  - http://dx.doi.org/10.1007/s00259-018-4148-3
+UR  - https://doi.org/10.1007/s00259-018-4148-3
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 ER  - 
 
@@ -683,7 +683,7 @@ PB  - Springer US
 SN  - 1860-2002
 DO  - 10.1007/s11307-016-0969-2
 M3  - 10.1007/s11307-016-0969-2
-UR  - http://dx.doi.org/10.1007/s11307-016-0969-2
+UR  - https://doi.org/10.1007/s11307-016-0969-2
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 ER  - 
 
@@ -701,7 +701,7 @@ PB  - Springer US
 SN  - 1573-482X
 DO  - 10.1007/s10854-013-1550-2
 M3  - 10.1007/s10854-013-1550-2
-UR  - http://dx.doi.org/10.1007/s10854-013-1550-2
+UR  - https://doi.org/10.1007/s10854-013-1550-2
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - r, B r i j e s h   K u m a
 A1  - k, B r a j e s h   K u m a r   K a u s h i
@@ -722,7 +722,7 @@ PB  - Springer-Verlag
 SN  - 1432-0630
 DO  - 10.1007/s00339-010-5867-x
 M3  - 10.1007/s00339-010-5867-x
-UR  - http://dx.doi.org/10.1007/s00339-010-5867-x
+UR  - https://doi.org/10.1007/s00339-010-5867-x
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - g, K .   C .   Y u n
 A1  - a, T .   S .   P l u r
@@ -742,7 +742,7 @@ PB  - Springer US
 SN  - 1860-2002
 DO  - 10.1007/s11307-016-1031-0
 M3  - 10.1007/s11307-016-1031-0
-UR  - http://dx.doi.org/10.1007/s11307-016-1031-0
+UR  - https://doi.org/10.1007/s11307-016-1031-0
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 ER  - 
 
@@ -760,7 +760,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1432-1017
 DO  - 10.1007/s00249-017-1222-x
 M3  - 10.1007/s00249-017-1222-x
-UR  - http://dx.doi.org/10.1007/s00249-017-1222-x
+UR  - https://doi.org/10.1007/s00249-017-1222-x
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 ER  - 
 
@@ -778,7 +778,7 @@ PB  - Springer Netherlands
 SN  - 1876-9918
 DO  - 10.1007/s12633-010-9055-6
 M3  - 10.1007/s12633-010-9055-6
-UR  - http://dx.doi.org/10.1007/s12633-010-9055-6
+UR  - https://doi.org/10.1007/s12633-010-9055-6
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - e, R a h u l   B h u r
 A1  - o, A n i l   M a h a p a t r
@@ -798,7 +798,7 @@ PB  - Korea Nano Technology Research Society
 SN  - 2196-5404
 DO  - 10.1186/s40580-014-0015-5
 M3  - 10.1186/s40580-014-0015-5
-UR  - http://dx.doi.org/10.1186/s40580-014-0015-5
+UR  - https://doi.org/10.1186/s40580-014-0015-5
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - e, S a n g   H o o n   C h a
 A1  - e, Y o u n g   H e e   L e
@@ -818,7 +818,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2005-4602
 DO  - 10.1007/s12541-016-0067-z
 M3  - 10.1007/s12541-016-0067-z
-UR  - http://dx.doi.org/10.1007/s12541-016-0067-z
+UR  - https://doi.org/10.1007/s12541-016-0067-z
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - k, J a n g h o o n   P a r
 A1  - n, K e e h y u n   S h i
@@ -839,7 +839,7 @@ PB  - Higher Education Press
 SN  - 2095-1698
 DO  - 10.1007/s11708-017-0463-9
 M3  - 10.1007/s11708-017-0463-9
-UR  - http://dx.doi.org/10.1007/s11708-017-0463-9
+UR  - https://doi.org/10.1007/s11708-017-0463-9
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - o, X i   Z h a
 A1  - u, S h u o   X
@@ -860,7 +860,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1619-7089
 DO  - 10.1007/s00259-016-3484-4
 M3  - 10.1007/s00259-016-3484-4
-UR  - http://dx.doi.org/10.1007/s00259-016-3484-4
+UR  - https://doi.org/10.1007/s00259-016-3484-4
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 ER  - 
 
@@ -878,7 +878,7 @@ PB  - Springer-Verlag
 SN  - 1860-2002
 DO  - 10.1007/s11307-012-0598-3
 M3  - 10.1007/s11307-012-0598-3
-UR  - http://dx.doi.org/10.1007/s11307-012-0598-3
+UR  - https://doi.org/10.1007/s11307-012-0598-3
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 ER  - 
 
@@ -896,7 +896,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1618-2650
 DO  - 10.1007/s00216-013-6911-4
 M3  - 10.1007/s00216-013-6911-4
-UR  - http://dx.doi.org/10.1007/s00216-013-6911-4
+UR  - https://doi.org/10.1007/s00216-013-6911-4
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - y, E m i l i a   W .   N e r
 A1  - a, L a u r o   T .   K u b o t
@@ -916,7 +916,7 @@ PB  - Science China Press
 SN  - 1869-1919
 DO  - 10.1007/s11432-018-9396-7
 M3  - 10.1007/s11432-018-9396-7
-UR  - http://dx.doi.org/10.1007/s11432-018-9396-7
+UR  - https://doi.org/10.1007/s11432-018-9396-7
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 A1  - n, S i h o n g   C h e
 A1  - n, T a i s o n g   P a
@@ -939,7 +939,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1619-7089
 DO  - 10.1007/s00259-013-2535-3
 M3  - 10.1007/s00259-013-2535-3
-UR  - http://dx.doi.org/10.1007/s00259-013-2535-3
+UR  - https://doi.org/10.1007/s00259-013-2535-3
 N2  - This paper presents rapid and cost-efficient prototyping metalizing method for fabrication of metal contacts. It demonstrates the technical improvement in metalizing achieved by transparency photomask printing compared to conventional methods. It describes fabrication of microelectrodes on various substrates such as glass and plastic using conventional office laser printer. Presented method can be used for quick prototyping of sensors, microheaters, micro hotplates and metal interconnects. Experimental results showed that prepared metallic micro contacts on glass substrate are compatible with conventional soldering.
 ER  - 
 
@@ -957,7 +957,7 @@ PB  - Springer US
 SN  - 1573-4803
 DO  - 10.1007/s10853-018-3171-x
 M3  - 10.1007/s10853-018-3171-x
-UR  - http://dx.doi.org/10.1007/s10853-018-3171-x
+UR  - https://doi.org/10.1007/s10853-018-3171-x
 N2  - Highly stretchable supersensitive sensors represent a new epoch in the field of intelligent medical devices. Applications include the detection of various stimuli of the human body and environmental monitoring around biological surfaces. To provide more accurate measurement results, stretchable sensors must be tightly attached on the skin surface or to clothing. Consequently, stretchable sensors must fulfill many requirements, such as high stretchability, high comfortability, high sensitivity, and long-term wear. To address these challenges, investigators have devoted considerable research effort to the development of technology, and much progress has been achieved. Here, recent developments with stretchable sensors are described, including human motion monitoring sensors, vital sign monitoring sensors, and sensors for environmental monitoring around biological surfaces. The latest successful examples of supersensitive sensors for achieving stretchability by novel materials or structures are reviewed. In the next section, recent advances regarding processing technology innovations are introduced. Future research directions and challenges in developing a highly stretchable supersensitive sensor for wearable biomedical applications are also discussed. With the development of new materials and novel technologies, and given the interdisciplinary nature of the research, the functionalities of stretchable sensors will become more powerful, and stretchable sensor technology will become more mature.
 A1  - o, Q i n w u   G a
 A1  - g, J i n j i e   Z h a n
@@ -982,7 +982,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1869-4101
 DO  - 10.1007/s13244-018-0603-8
 M3  - 10.1007/s13244-018-0603-8
-UR  - http://dx.doi.org/10.1007/s13244-018-0603-8
+UR  - https://doi.org/10.1007/s13244-018-0603-8
 N2  - Highly stretchable supersensitive sensors represent a new epoch in the field of intelligent medical devices. Applications include the detection of various stimuli of the human body and environmental monitoring around biological surfaces. To provide more accurate measurement results, stretchable sensors must be tightly attached on the skin surface or to clothing. Consequently, stretchable sensors must fulfill many requirements, such as high stretchability, high comfortability, high sensitivity, and long-term wear. To address these challenges, investigators have devoted considerable research effort to the development of technology, and much progress has been achieved. Here, recent developments with stretchable sensors are described, including human motion monitoring sensors, vital sign monitoring sensors, and sensors for environmental monitoring around biological surfaces. The latest successful examples of supersensitive sensors for achieving stretchability by novel materials or structures are reviewed. In the next section, recent advances regarding processing technology innovations are introduced. Future research directions and challenges in developing a highly stretchable supersensitive sensor for wearable biomedical applications are also discussed. With the development of new materials and novel technologies, and given the interdisciplinary nature of the research, the functionalities of stretchable sensors will become more powerful, and stretchable sensor technology will become more mature.
 ER  - 
 
@@ -1000,7 +1000,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1861-6429
 DO  - 10.1007/s11548-015-1213-2
 M3  - 10.1007/s11548-015-1213-2
-UR  - http://dx.doi.org/10.1007/s11548-015-1213-2
+UR  - https://doi.org/10.1007/s11548-015-1213-2
 N2  - Highly stretchable supersensitive sensors represent a new epoch in the field of intelligent medical devices. Applications include the detection of various stimuli of the human body and environmental monitoring around biological surfaces. To provide more accurate measurement results, stretchable sensors must be tightly attached on the skin surface or to clothing. Consequently, stretchable sensors must fulfill many requirements, such as high stretchability, high comfortability, high sensitivity, and long-term wear. To address these challenges, investigators have devoted considerable research effort to the development of technology, and much progress has been achieved. Here, recent developments with stretchable sensors are described, including human motion monitoring sensors, vital sign monitoring sensors, and sensors for environmental monitoring around biological surfaces. The latest successful examples of supersensitive sensors for achieving stretchability by novel materials or structures are reviewed. In the next section, recent advances regarding processing technology innovations are introduced. Future research directions and challenges in developing a highly stretchable supersensitive sensor for wearable biomedical applications are also discussed. With the development of new materials and novel technologies, and given the interdisciplinary nature of the research, the functionalities of stretchable sensors will become more powerful, and stretchable sensor technology will become more mature.
 ER  - 
 
@@ -1018,7 +1018,7 @@ PB  - Springer US
 SN  - 1860-2002
 DO  - 10.1007/s11307-017-1138-y
 M3  - 10.1007/s11307-017-1138-y
-UR  - http://dx.doi.org/10.1007/s11307-017-1138-y
+UR  - https://doi.org/10.1007/s11307-017-1138-y
 N2  - Highly stretchable supersensitive sensors represent a new epoch in the field of intelligent medical devices. Applications include the detection of various stimuli of the human body and environmental monitoring around biological surfaces. To provide more accurate measurement results, stretchable sensors must be tightly attached on the skin surface or to clothing. Consequently, stretchable sensors must fulfill many requirements, such as high stretchability, high comfortability, high sensitivity, and long-term wear. To address these challenges, investigators have devoted considerable research effort to the development of technology, and much progress has been achieved. Here, recent developments with stretchable sensors are described, including human motion monitoring sensors, vital sign monitoring sensors, and sensors for environmental monitoring around biological surfaces. The latest successful examples of supersensitive sensors for achieving stretchability by novel materials or structures are reviewed. In the next section, recent advances regarding processing technology innovations are introduced. Future research directions and challenges in developing a highly stretchable supersensitive sensor for wearable biomedical applications are also discussed. With the development of new materials and novel technologies, and given the interdisciplinary nature of the research, the functionalities of stretchable sensors will become more powerful, and stretchable sensor technology will become more mature.
 ER  - 
 
@@ -1036,7 +1036,7 @@ PB  - Korean Society of Rheology, Australian Society of Rheology
 SN  - 2093-7660
 DO  - 10.1007/s13367-014-0005-5
 M3  - 10.1007/s13367-014-0005-5
-UR  - http://dx.doi.org/10.1007/s13367-014-0005-5
+UR  - https://doi.org/10.1007/s13367-014-0005-5
 N2  - Highly stretchable supersensitive sensors represent a new epoch in the field of intelligent medical devices. Applications include the detection of various stimuli of the human body and environmental monitoring around biological surfaces. To provide more accurate measurement results, stretchable sensors must be tightly attached on the skin surface or to clothing. Consequently, stretchable sensors must fulfill many requirements, such as high stretchability, high comfortability, high sensitivity, and long-term wear. To address these challenges, investigators have devoted considerable research effort to the development of technology, and much progress has been achieved. Here, recent developments with stretchable sensors are described, including human motion monitoring sensors, vital sign monitoring sensors, and sensors for environmental monitoring around biological surfaces. The latest successful examples of supersensitive sensors for achieving stretchability by novel materials or structures are reviewed. In the next section, recent advances regarding processing technology innovations are introduced. Future research directions and challenges in developing a highly stretchable supersensitive sensor for wearable biomedical applications are also discussed. With the development of new materials and novel technologies, and given the interdisciplinary nature of the research, the functionalities of stretchable sensors will become more powerful, and stretchable sensor technology will become more mature.
 A1  - n, H y u n s i k   Y o o
 A1  - e, H y e m i n   L e
@@ -1057,7 +1057,7 @@ PB  - The Korean Institute of Metals and Materials
 SN  - 2093-6788
 DO  - 10.1007/s13391-018-0044-z
 M3  - 10.1007/s13391-018-0044-z
-UR  - http://dx.doi.org/10.1007/s13391-018-0044-z
+UR  - https://doi.org/10.1007/s13391-018-0044-z
 N2  - Two-dimensional (2D) nanostructures are gaining tremendous interests due to the fascinating physical, chemical, electrical, and optical properties. Recent advances in 2D nanomaterials synthesis have contributed to optimization of various parameters such as physical dimension and chemical structure for specific applications. In particular, development of high performance gas sensors is gaining vast importance for real-time and on-site environmental monitoring by detection of hazardous chemical species. In this review, we comprehensively report recent achievements of 2D nanostructured materials for chemiresistive-type gas sensors. Firstly, the basic sensing mechanism is described based on charge transfer behavior between gas species and 2D nanomaterials. Secondly, diverse synthesis strategies and characteristic gas sensing properties of 2D nanostructures such as graphene, metal oxides, transition metal dichalcogenides (TMDs), metal organic frameworks (MOFs), phosphorus, and MXenes are presented. In addition, recent trends in synthesis of 2D heterostructures by integrating two different types of 2D nanomaterials and their gas sensing properties are discussed. Finally, this review provides perspectives and future research directions for gas sensor technology using various 2D nanomaterials.
 A1  - i, S e o n - J i n   C h o
 A1  - m, I l - D o o   K i
@@ -1077,7 +1077,7 @@ PB  - The Korean Institute of Metals and Materials
 SN  - 2093-6788
 DO  - 10.1007/s13391-011-0270-0
 M3  - 10.1007/s13391-011-0270-0
-UR  - http://dx.doi.org/10.1007/s13391-011-0270-0
+UR  - https://doi.org/10.1007/s13391-011-0270-0
 N2  - Two-dimensional (2D) nanostructures are gaining tremendous interests due to the fascinating physical, chemical, electrical, and optical properties. Recent advances in 2D nanomaterials synthesis have contributed to optimization of various parameters such as physical dimension and chemical structure for specific applications. In particular, development of high performance gas sensors is gaining vast importance for real-time and on-site environmental monitoring by detection of hazardous chemical species. In this review, we comprehensively report recent achievements of 2D nanostructured materials for chemiresistive-type gas sensors. Firstly, the basic sensing mechanism is described based on charge transfer behavior between gas species and 2D nanomaterials. Secondly, diverse synthesis strategies and characteristic gas sensing properties of 2D nanostructures such as graphene, metal oxides, transition metal dichalcogenides (TMDs), metal organic frameworks (MOFs), phosphorus, and MXenes are presented. In addition, recent trends in synthesis of 2D heterostructures by integrating two different types of 2D nanomaterials and their gas sensing properties are discussed. Finally, this review provides perspectives and future research directions for gas sensor technology using various 2D nanomaterials.
 A1  - o, T a e - G y u   W o
 A1  - k, I l - S o n g   P a r
@@ -1100,7 +1100,7 @@ PB  - Springer-Verlag
 SN  - 1432-1017
 DO  - 10.1007/s00249-011-0734-z
 M3  - 10.1007/s00249-011-0734-z
-UR  - http://dx.doi.org/10.1007/s00249-011-0734-z
+UR  - https://doi.org/10.1007/s00249-011-0734-z
 N2  - Two-dimensional (2D) nanostructures are gaining tremendous interests due to the fascinating physical, chemical, electrical, and optical properties. Recent advances in 2D nanomaterials synthesis have contributed to optimization of various parameters such as physical dimension and chemical structure for specific applications. In particular, development of high performance gas sensors is gaining vast importance for real-time and on-site environmental monitoring by detection of hazardous chemical species. In this review, we comprehensively report recent achievements of 2D nanostructured materials for chemiresistive-type gas sensors. Firstly, the basic sensing mechanism is described based on charge transfer behavior between gas species and 2D nanomaterials. Secondly, diverse synthesis strategies and characteristic gas sensing properties of 2D nanostructures such as graphene, metal oxides, transition metal dichalcogenides (TMDs), metal organic frameworks (MOFs), phosphorus, and MXenes are presented. In addition, recent trends in synthesis of 2D heterostructures by integrating two different types of 2D nanomaterials and their gas sensing properties are discussed. Finally, this review provides perspectives and future research directions for gas sensor technology using various 2D nanomaterials.
 ER  - 
 
@@ -1118,7 +1118,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1869-4101
 DO  - 10.1007/s13244-017-0546-5
 M3  - 10.1007/s13244-017-0546-5
-UR  - http://dx.doi.org/10.1007/s13244-017-0546-5
+UR  - https://doi.org/10.1007/s13244-017-0546-5
 N2  - Two-dimensional (2D) nanostructures are gaining tremendous interests due to the fascinating physical, chemical, electrical, and optical properties. Recent advances in 2D nanomaterials synthesis have contributed to optimization of various parameters such as physical dimension and chemical structure for specific applications. In particular, development of high performance gas sensors is gaining vast importance for real-time and on-site environmental monitoring by detection of hazardous chemical species. In this review, we comprehensively report recent achievements of 2D nanostructured materials for chemiresistive-type gas sensors. Firstly, the basic sensing mechanism is described based on charge transfer behavior between gas species and 2D nanomaterials. Secondly, diverse synthesis strategies and characteristic gas sensing properties of 2D nanostructures such as graphene, metal oxides, transition metal dichalcogenides (TMDs), metal organic frameworks (MOFs), phosphorus, and MXenes are presented. In addition, recent trends in synthesis of 2D heterostructures by integrating two different types of 2D nanomaterials and their gas sensing properties are discussed. Finally, this review provides perspectives and future research directions for gas sensor technology using various 2D nanomaterials.
 ER  - 
 
@@ -1136,7 +1136,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1619-7089
 DO  - 10.1007/s00259-015-3198-z
 M3  - 10.1007/s00259-015-3198-z
-UR  - http://dx.doi.org/10.1007/s00259-015-3198-z
+UR  - https://doi.org/10.1007/s00259-015-3198-z
 N2  - Two-dimensional (2D) nanostructures are gaining tremendous interests due to the fascinating physical, chemical, electrical, and optical properties. Recent advances in 2D nanomaterials synthesis have contributed to optimization of various parameters such as physical dimension and chemical structure for specific applications. In particular, development of high performance gas sensors is gaining vast importance for real-time and on-site environmental monitoring by detection of hazardous chemical species. In this review, we comprehensively report recent achievements of 2D nanostructured materials for chemiresistive-type gas sensors. Firstly, the basic sensing mechanism is described based on charge transfer behavior between gas species and 2D nanomaterials. Secondly, diverse synthesis strategies and characteristic gas sensing properties of 2D nanostructures such as graphene, metal oxides, transition metal dichalcogenides (TMDs), metal organic frameworks (MOFs), phosphorus, and MXenes are presented. In addition, recent trends in synthesis of 2D heterostructures by integrating two different types of 2D nanomaterials and their gas sensing properties are discussed. Finally, this review provides perspectives and future research directions for gas sensor technology using various 2D nanomaterials.
 ER  - 
 
@@ -1154,7 +1154,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-014-0502-3
 M3  - 10.1007/s12274-014-0502-3
-UR  - http://dx.doi.org/10.1007/s12274-014-0502-3
+UR  - https://doi.org/10.1007/s12274-014-0502-3
 N2  - Two-dimensional (2D) nanostructures are gaining tremendous interests due to the fascinating physical, chemical, electrical, and optical properties. Recent advances in 2D nanomaterials synthesis have contributed to optimization of various parameters such as physical dimension and chemical structure for specific applications. In particular, development of high performance gas sensors is gaining vast importance for real-time and on-site environmental monitoring by detection of hazardous chemical species. In this review, we comprehensively report recent achievements of 2D nanostructured materials for chemiresistive-type gas sensors. Firstly, the basic sensing mechanism is described based on charge transfer behavior between gas species and 2D nanomaterials. Secondly, diverse synthesis strategies and characteristic gas sensing properties of 2D nanostructures such as graphene, metal oxides, transition metal dichalcogenides (TMDs), metal organic frameworks (MOFs), phosphorus, and MXenes are presented. In addition, recent trends in synthesis of 2D heterostructures by integrating two different types of 2D nanomaterials and their gas sensing properties are discussed. Finally, this review provides perspectives and future research directions for gas sensor technology using various 2D nanomaterials.
 A1  - g, M y u n g k w a n   S o n
 A1  - k, J o n g   H y u n   P a r
@@ -1180,7 +1180,7 @@ PB  - Springer US
 SN  - 1544-1016
 DO  - 10.1007/s11666-010-9475-2
 M3  - 10.1007/s11666-010-9475-2
-UR  - http://dx.doi.org/10.1007/s11666-010-9475-2
+UR  - https://doi.org/10.1007/s11666-010-9475-2
 N2  - Two-dimensional (2D) nanostructures are gaining tremendous interests due to the fascinating physical, chemical, electrical, and optical properties. Recent advances in 2D nanomaterials synthesis have contributed to optimization of various parameters such as physical dimension and chemical structure for specific applications. In particular, development of high performance gas sensors is gaining vast importance for real-time and on-site environmental monitoring by detection of hazardous chemical species. In this review, we comprehensively report recent achievements of 2D nanostructured materials for chemiresistive-type gas sensors. Firstly, the basic sensing mechanism is described based on charge transfer behavior between gas species and 2D nanomaterials. Secondly, diverse synthesis strategies and characteristic gas sensing properties of 2D nanostructures such as graphene, metal oxides, transition metal dichalcogenides (TMDs), metal organic frameworks (MOFs), phosphorus, and MXenes are presented. In addition, recent trends in synthesis of 2D heterostructures by integrating two different types of 2D nanomaterials and their gas sensing properties are discussed. Finally, this review provides perspectives and future research directions for gas sensor technology using various 2D nanomaterials.
 A1  - h, S a n j a y   S a m p a t
 ER  - 
@@ -1199,7 +1199,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1432-0630
 DO  - 10.1007/s00339-018-2071-x
 M3  - 10.1007/s00339-018-2071-x
-UR  - http://dx.doi.org/10.1007/s00339-018-2071-x
+UR  - https://doi.org/10.1007/s00339-018-2071-x
 N2  - This paper proposed a simple way to prepare electrically conductive multifunctional fabrics made by imparting copper nanoparticles and followed with copper electroplating. The surface and ageing properties of copper nanoparticles coated fabric were investigated. Furthermore, the problems regarding ageing properties were solved in a very simple way and various functional properties were studied. The effect of electroplating parameters (concentration of acid) against the stretch rate of fabric was studied. The influence of operating parameters on copper nanoparticles coated fabrics were characterized by Zetasizer, scanning electron micrograph, X-ray diffraction analysis, differential scanning calorimeter. Increase in electrical properties with the rate of weight gain was analyzed. The utility of simple nanoparticles coated and copper electroplated conductive fabrics were analyzed for electromagnetic shielding ability over a frequency range of 30 MHz–1.5 GHz. Furthermore, the heating performances of the fabrics were studied through measuring the change in temperature at the surface of the fabric while applying a voltage difference across the fabric. Moreover, the role coated fabrics against anti-corrosion test was performed to check the durability of electroplating.
 A1  - i, A z a m   A l
 A1  - i, V i j a y   B a h e t
@@ -1221,7 +1221,7 @@ PB  - Springer Netherlands
 SN  - 1572-882X
 DO  - 10.1007/s10570-013-9973-8
 M3  - 10.1007/s10570-013-9973-8
-UR  - http://dx.doi.org/10.1007/s10570-013-9973-8
+UR  - https://doi.org/10.1007/s10570-013-9973-8
 N2  - This paper proposed a simple way to prepare electrically conductive multifunctional fabrics made by imparting copper nanoparticles and followed with copper electroplating. The surface and ageing properties of copper nanoparticles coated fabric were investigated. Furthermore, the problems regarding ageing properties were solved in a very simple way and various functional properties were studied. The effect of electroplating parameters (concentration of acid) against the stretch rate of fabric was studied. The influence of operating parameters on copper nanoparticles coated fabrics were characterized by Zetasizer, scanning electron micrograph, X-ray diffraction analysis, differential scanning calorimeter. Increase in electrical properties with the rate of weight gain was analyzed. The utility of simple nanoparticles coated and copper electroplated conductive fabrics were analyzed for electromagnetic shielding ability over a frequency range of 30 MHz–1.5 GHz. Furthermore, the heating performances of the fabrics were studied through measuring the change in temperature at the surface of the fabric while applying a voltage difference across the fabric. Moreover, the role coated fabrics against anti-corrosion test was performed to check the durability of electroplating.
 A1  - r, L a r a   J a b b o u
 A1  - i, R o b e r t a   B o n g i o v a n n
@@ -1244,7 +1244,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 2150-5551
 DO  - 10.1007/BF03353759
 M3  - 10.1007/BF03353759
-UR  - http://dx.doi.org/10.1007/BF03353759
+UR  - https://doi.org/10.1007/BF03353759
 N2  - This paper proposed a simple way to prepare electrically conductive multifunctional fabrics made by imparting copper nanoparticles and followed with copper electroplating. The surface and ageing properties of copper nanoparticles coated fabric were investigated. Furthermore, the problems regarding ageing properties were solved in a very simple way and various functional properties were studied. The effect of electroplating parameters (concentration of acid) against the stretch rate of fabric was studied. The influence of operating parameters on copper nanoparticles coated fabrics were characterized by Zetasizer, scanning electron micrograph, X-ray diffraction analysis, differential scanning calorimeter. Increase in electrical properties with the rate of weight gain was analyzed. The utility of simple nanoparticles coated and copper electroplated conductive fabrics were analyzed for electromagnetic shielding ability over a frequency range of 30 MHz–1.5 GHz. Furthermore, the heating performances of the fabrics were studied through measuring the change in temperature at the surface of the fabric while applying a voltage difference across the fabric. Moreover, the role coated fabrics against anti-corrosion test was performed to check the durability of electroplating.
 A1  - n, J i e   S h e
 A1  - g, D i n g w e n   Z h a n
@@ -1268,7 +1268,7 @@ PB  - Higher Education Press
 SN  - 2095-0241
 DO  - 10.1007/s11465-017-0484-4
 M3  - 10.1007/s11465-017-0484-4
-UR  - http://dx.doi.org/10.1007/s11465-017-0484-4
+UR  - https://doi.org/10.1007/s11465-017-0484-4
 N2  - This paper proposed a simple way to prepare electrically conductive multifunctional fabrics made by imparting copper nanoparticles and followed with copper electroplating. The surface and ageing properties of copper nanoparticles coated fabric were investigated. Furthermore, the problems regarding ageing properties were solved in a very simple way and various functional properties were studied. The effect of electroplating parameters (concentration of acid) against the stretch rate of fabric was studied. The influence of operating parameters on copper nanoparticles coated fabrics were characterized by Zetasizer, scanning electron micrograph, X-ray diffraction analysis, differential scanning calorimeter. Increase in electrical properties with the rate of weight gain was analyzed. The utility of simple nanoparticles coated and copper electroplated conductive fabrics were analyzed for electromagnetic shielding ability over a frequency range of 30 MHz–1.5 GHz. Furthermore, the heating performances of the fabrics were studied through measuring the change in temperature at the surface of the fabric while applying a voltage difference across the fabric. Moreover, the role coated fabrics against anti-corrosion test was performed to check the durability of electroplating.
 A1  - h, K w o k   S i o n g   T e
 ER  - 
@@ -1287,7 +1287,7 @@ PB  - Springer US
 SN  - 1544-1016
 DO  - 10.1007/s11666-016-0473-x
 M3  - 10.1007/s11666-016-0473-x
-UR  - http://dx.doi.org/10.1007/s11666-016-0473-x
+UR  - https://doi.org/10.1007/s11666-016-0473-x
 N2  - Considerable progress has been made over the last decades in thermal spray technologies, practices and applications. However, like other technologies, they have to continuously evolve to meet new problems and market requirements. This article aims to identify the current challenges limiting the evolution of these technologies and to propose research directions and priorities to meet these challenges. It was prepared on the basis of a collection of short articles written by experts in thermal spray who were asked to present a snapshot of the current state of their specific field, give their views on current challenges faced by the field and provide some guidance as to the R&D required to meet these challenges. The article is divided in three sections that deal with the emerging thermal spray processes, coating properties and function, and biomedical, electronic, aerospace and energy generation applications.
 A1  - e, A r m e l l e   V a r d e l l
 A1  - u, C h r i s t i a n   M o r e a
@@ -1347,7 +1347,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-017-1941-4
 M3  - 10.1007/s12274-017-1941-4
-UR  - http://dx.doi.org/10.1007/s12274-017-1941-4
+UR  - https://doi.org/10.1007/s12274-017-1941-4
 N2  - Considerable progress has been made over the last decades in thermal spray technologies, practices and applications. However, like other technologies, they have to continuously evolve to meet new problems and market requirements. This article aims to identify the current challenges limiting the evolution of these technologies and to propose research directions and priorities to meet these challenges. It was prepared on the basis of a collection of short articles written by experts in thermal spray who were asked to present a snapshot of the current state of their specific field, give their views on current challenges faced by the field and provide some guidance as to the R&D required to meet these challenges. The article is divided in three sections that deal with the emerging thermal spray processes, coating properties and function, and biomedical, electronic, aerospace and energy generation applications.
 A1  - n, C h a n g y o n g   L a
 A1  - u, Z i y a o   Z h o
@@ -1375,7 +1375,7 @@ PB  - Springer US
 SN  - 1572-8781
 DO  - 10.1007/s10544-009-9361-1
 M3  - 10.1007/s10544-009-9361-1
-UR  - http://dx.doi.org/10.1007/s10544-009-9361-1
+UR  - https://doi.org/10.1007/s10544-009-9361-1
 N2  - Considerable progress has been made over the last decades in thermal spray technologies, practices and applications. However, like other technologies, they have to continuously evolve to meet new problems and market requirements. This article aims to identify the current challenges limiting the evolution of these technologies and to propose research directions and priorities to meet these challenges. It was prepared on the basis of a collection of short articles written by experts in thermal spray who were asked to present a snapshot of the current state of their specific field, give their views on current challenges faced by the field and provide some guidance as to the R&D required to meet these challenges. The article is divided in three sections that deal with the emerging thermal spray processes, coating properties and function, and biomedical, electronic, aerospace and energy generation applications.
 A1  - n, J e f f r e y   T .   B o r e n s t e i
 A1  - r, M a l i n d a   M .   T u p p e
@@ -1400,7 +1400,7 @@ PB  - Springer Vienna
 SN  - 1436-5073
 DO  - 10.1007/s00604-017-2280-6
 M3  - 10.1007/s00604-017-2280-6
-UR  - http://dx.doi.org/10.1007/s00604-017-2280-6
+UR  - https://doi.org/10.1007/s00604-017-2280-6
 N2  - The authors describe a liquid crystal polymer (LCP) based bismuth (Bi) film electrode that can be directly deployed for in-situ determination of zinc(II) ions. The use of an LCP warrants improved operational reliability, high durability, and flexibility of the sensor, allowing it to be mounted on any flat or shaped surface. Square wave anodic stripping voltammetry shows the sensor to be able to detect Zn(II) (−1.64 V vs. thin-film Ag/AgCl reference electrode) in concentrations as low as 1.22 nM at a deposition time of 180 s. Other figures of merit include (a) an analytical sensitivity of 1.55 nA∙nM−1∙mm−2, (b) a linear detection range extending from 4.59 to 1071 nM, (c) a repeatability with a relative standard deviation of 3.35% (for n = 10), (d) a reproducibility with a relative standard deviation of 1.64% (for n = 6). Real-time applicability of the sensor for in-situ detection was demonstrated by determination of Zn(II) in seawater. In an extension of the method, a flexible sensor array consisting of four LCP-based sensors was attached to the hull of an autonomous kayak, which was remotely operated. The response of the sensor array indicated a clear trace of Zn(II) concentrations in seawater. This was confirmed by ICP-MS analysis. The results suggest the potential usage of the flexible LCP electrochemical sensor for in-situ monitoring.
 A1  - g, N a n   W a n
 A1  - e, E l g a r   K a n h e r
@@ -1423,7 +1423,7 @@ PB  - SP Versita
 SN  - 1896-3757
 DO  - 10.2478/s11772-010-0008-9
 M3  - 10.2478/s11772-010-0008-9
-UR  - http://dx.doi.org/10.2478/s11772-010-0008-9
+UR  - https://doi.org/10.2478/s11772-010-0008-9
 N2  - The authors describe a liquid crystal polymer (LCP) based bismuth (Bi) film electrode that can be directly deployed for in-situ determination of zinc(II) ions. The use of an LCP warrants improved operational reliability, high durability, and flexibility of the sensor, allowing it to be mounted on any flat or shaped surface. Square wave anodic stripping voltammetry shows the sensor to be able to detect Zn(II) (−1.64 V vs. thin-film Ag/AgCl reference electrode) in concentrations as low as 1.22 nM at a deposition time of 180 s. Other figures of merit include (a) an analytical sensitivity of 1.55 nA∙nM−1∙mm−2, (b) a linear detection range extending from 4.59 to 1071 nM, (c) a repeatability with a relative standard deviation of 3.35% (for n = 10), (d) a reproducibility with a relative standard deviation of 1.64% (for n = 6). Real-time applicability of the sensor for in-situ detection was demonstrated by determination of Zn(II) in seawater. In an extension of the method, a flexible sensor array consisting of four LCP-based sensors was attached to the hull of an autonomous kayak, which was remotely operated. The response of the sensor array indicated a clear trace of Zn(II) concentrations in seawater. This was confirmed by ICP-MS analysis. The results suggest the potential usage of the flexible LCP electrochemical sensor for in-situ monitoring.
 A1  - i, M .   J .   M a ł a c h o w s k
 A1  - a, J .   Ż m i j
@@ -1443,7 +1443,7 @@ PB  - Springer US
 SN  - 1525-1497
 DO  - 10.1007/s11606-017-4028-8
 M3  - 10.1007/s11606-017-4028-8
-UR  - http://dx.doi.org/10.1007/s11606-017-4028-8
+UR  - https://doi.org/10.1007/s11606-017-4028-8
 N2  - The authors describe a liquid crystal polymer (LCP) based bismuth (Bi) film electrode that can be directly deployed for in-situ determination of zinc(II) ions. The use of an LCP warrants improved operational reliability, high durability, and flexibility of the sensor, allowing it to be mounted on any flat or shaped surface. Square wave anodic stripping voltammetry shows the sensor to be able to detect Zn(II) (−1.64 V vs. thin-film Ag/AgCl reference electrode) in concentrations as low as 1.22 nM at a deposition time of 180 s. Other figures of merit include (a) an analytical sensitivity of 1.55 nA∙nM−1∙mm−2, (b) a linear detection range extending from 4.59 to 1071 nM, (c) a repeatability with a relative standard deviation of 3.35% (for n = 10), (d) a reproducibility with a relative standard deviation of 1.64% (for n = 6). Real-time applicability of the sensor for in-situ detection was demonstrated by determination of Zn(II) in seawater. In an extension of the method, a flexible sensor array consisting of four LCP-based sensors was attached to the hull of an autonomous kayak, which was remotely operated. The response of the sensor array indicated a clear trace of Zn(II) concentrations in seawater. This was confirmed by ICP-MS analysis. The results suggest the potential usage of the flexible LCP electrochemical sensor for in-situ monitoring.
 ER  - 
 
@@ -1461,7 +1461,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-017-1449-y
 M3  - 10.1007/s12274-017-1449-y
-UR  - http://dx.doi.org/10.1007/s12274-017-1449-y
+UR  - https://doi.org/10.1007/s12274-017-1449-y
 N2  - The authors describe a liquid crystal polymer (LCP) based bismuth (Bi) film electrode that can be directly deployed for in-situ determination of zinc(II) ions. The use of an LCP warrants improved operational reliability, high durability, and flexibility of the sensor, allowing it to be mounted on any flat or shaped surface. Square wave anodic stripping voltammetry shows the sensor to be able to detect Zn(II) (−1.64 V vs. thin-film Ag/AgCl reference electrode) in concentrations as low as 1.22 nM at a deposition time of 180 s. Other figures of merit include (a) an analytical sensitivity of 1.55 nA∙nM−1∙mm−2, (b) a linear detection range extending from 4.59 to 1071 nM, (c) a repeatability with a relative standard deviation of 3.35% (for n = 10), (d) a reproducibility with a relative standard deviation of 1.64% (for n = 6). Real-time applicability of the sensor for in-situ detection was demonstrated by determination of Zn(II) in seawater. In an extension of the method, a flexible sensor array consisting of four LCP-based sensors was attached to the hull of an autonomous kayak, which was remotely operated. The response of the sensor array indicated a clear trace of Zn(II) concentrations in seawater. This was confirmed by ICP-MS analysis. The results suggest the potential usage of the flexible LCP electrochemical sensor for in-situ monitoring.
 A1  - g, B y u n g   C h u l   J a n
 A1  - g, S a n g   Y o o n   Y a n
@@ -1486,7 +1486,7 @@ PB  - Springer India
 SN  - 1936-0541
 DO  - 10.1007/s12072-016-9783-9
 M3  - 10.1007/s12072-016-9783-9
-UR  - http://dx.doi.org/10.1007/s12072-016-9783-9
+UR  - https://doi.org/10.1007/s12072-016-9783-9
 N2  - The authors describe a liquid crystal polymer (LCP) based bismuth (Bi) film electrode that can be directly deployed for in-situ determination of zinc(II) ions. The use of an LCP warrants improved operational reliability, high durability, and flexibility of the sensor, allowing it to be mounted on any flat or shaped surface. Square wave anodic stripping voltammetry shows the sensor to be able to detect Zn(II) (−1.64 V vs. thin-film Ag/AgCl reference electrode) in concentrations as low as 1.22 nM at a deposition time of 180 s. Other figures of merit include (a) an analytical sensitivity of 1.55 nA∙nM−1∙mm−2, (b) a linear detection range extending from 4.59 to 1071 nM, (c) a repeatability with a relative standard deviation of 3.35% (for n = 10), (d) a reproducibility with a relative standard deviation of 1.64% (for n = 6). Real-time applicability of the sensor for in-situ detection was demonstrated by determination of Zn(II) in seawater. In an extension of the method, a flexible sensor array consisting of four LCP-based sensors was attached to the hull of an autonomous kayak, which was remotely operated. The response of the sensor array indicated a clear trace of Zn(II) concentrations in seawater. This was confirmed by ICP-MS analysis. The results suggest the potential usage of the flexible LCP electrochemical sensor for in-situ monitoring.
 ER  - 
 
@@ -1504,7 +1504,7 @@ PB  - Springer-Verlag
 SN  - 1432-1017
 DO  - 10.1007/s00249-013-0917-x
 M3  - 10.1007/s00249-013-0917-x
-UR  - http://dx.doi.org/10.1007/s00249-013-0917-x
+UR  - https://doi.org/10.1007/s00249-013-0917-x
 N2  - The authors describe a liquid crystal polymer (LCP) based bismuth (Bi) film electrode that can be directly deployed for in-situ determination of zinc(II) ions. The use of an LCP warrants improved operational reliability, high durability, and flexibility of the sensor, allowing it to be mounted on any flat or shaped surface. Square wave anodic stripping voltammetry shows the sensor to be able to detect Zn(II) (−1.64 V vs. thin-film Ag/AgCl reference electrode) in concentrations as low as 1.22 nM at a deposition time of 180 s. Other figures of merit include (a) an analytical sensitivity of 1.55 nA∙nM−1∙mm−2, (b) a linear detection range extending from 4.59 to 1071 nM, (c) a repeatability with a relative standard deviation of 3.35% (for n = 10), (d) a reproducibility with a relative standard deviation of 1.64% (for n = 6). Real-time applicability of the sensor for in-situ detection was demonstrated by determination of Zn(II) in seawater. In an extension of the method, a flexible sensor array consisting of four LCP-based sensors was attached to the hull of an autonomous kayak, which was remotely operated. The response of the sensor array indicated a clear trace of Zn(II) concentrations in seawater. This was confirmed by ICP-MS analysis. The results suggest the potential usage of the flexible LCP electrochemical sensor for in-situ monitoring.
 ER  - 
 
@@ -1522,7 +1522,7 @@ PB  - BioMed Central
 SN  - 2047-2994
 DO  - 10.1186/s13756-017-0201-4
 M3  - 10.1186/s13756-017-0201-4
-UR  - http://dx.doi.org/10.1186/s13756-017-0201-4
+UR  - https://doi.org/10.1186/s13756-017-0201-4
 N2  - The authors describe a liquid crystal polymer (LCP) based bismuth (Bi) film electrode that can be directly deployed for in-situ determination of zinc(II) ions. The use of an LCP warrants improved operational reliability, high durability, and flexibility of the sensor, allowing it to be mounted on any flat or shaped surface. Square wave anodic stripping voltammetry shows the sensor to be able to detect Zn(II) (−1.64 V vs. thin-film Ag/AgCl reference electrode) in concentrations as low as 1.22 nM at a deposition time of 180 s. Other figures of merit include (a) an analytical sensitivity of 1.55 nA∙nM−1∙mm−2, (b) a linear detection range extending from 4.59 to 1071 nM, (c) a repeatability with a relative standard deviation of 3.35% (for n = 10), (d) a reproducibility with a relative standard deviation of 1.64% (for n = 6). Real-time applicability of the sensor for in-situ detection was demonstrated by determination of Zn(II) in seawater. In an extension of the method, a flexible sensor array consisting of four LCP-based sensors was attached to the hull of an autonomous kayak, which was remotely operated. The response of the sensor array indicated a clear trace of Zn(II) concentrations in seawater. This was confirmed by ICP-MS analysis. The results suggest the potential usage of the flexible LCP electrochemical sensor for in-situ monitoring.
 ER  - 
 
@@ -1540,7 +1540,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2198-0810
 DO  - 10.1007/s40684-016-0028-0
 M3  - 10.1007/s40684-016-0028-0
-UR  - http://dx.doi.org/10.1007/s40684-016-0028-0
+UR  - https://doi.org/10.1007/s40684-016-0028-0
 N2  - The authors describe a liquid crystal polymer (LCP) based bismuth (Bi) film electrode that can be directly deployed for in-situ determination of zinc(II) ions. The use of an LCP warrants improved operational reliability, high durability, and flexibility of the sensor, allowing it to be mounted on any flat or shaped surface. Square wave anodic stripping voltammetry shows the sensor to be able to detect Zn(II) (−1.64 V vs. thin-film Ag/AgCl reference electrode) in concentrations as low as 1.22 nM at a deposition time of 180 s. Other figures of merit include (a) an analytical sensitivity of 1.55 nA∙nM−1∙mm−2, (b) a linear detection range extending from 4.59 to 1071 nM, (c) a repeatability with a relative standard deviation of 3.35% (for n = 10), (d) a reproducibility with a relative standard deviation of 1.64% (for n = 6). Real-time applicability of the sensor for in-situ detection was demonstrated by determination of Zn(II) in seawater. In an extension of the method, a flexible sensor array consisting of four LCP-based sensors was attached to the hull of an autonomous kayak, which was remotely operated. The response of the sensor array indicated a clear trace of Zn(II) concentrations in seawater. This was confirmed by ICP-MS analysis. The results suggest the potential usage of the flexible LCP electrochemical sensor for in-situ monitoring.
 A1  - u, W o n - S h i k   C h
 A1  - m, M i n - S o o   K i
@@ -1574,7 +1574,7 @@ PB  - Springer US
 SN  - 1573-482X
 DO  - 10.1007/s10854-016-5476-3
 M3  - 10.1007/s10854-016-5476-3
-UR  - http://dx.doi.org/10.1007/s10854-016-5476-3
+UR  - https://doi.org/10.1007/s10854-016-5476-3
 N2  - In this study, we present a new simple method using formic acid pretreatment to achieve low temperature sintering of Cu nanoparticles, and the Cu nanoparticles have been successfully prepared with a modified polyol method. For formic acid pretreatment, the spherical Cu nanoparticles with an average size of 30 nm were saturated with a mixed solution of formic acid and absolute ethanol directly. The surface composition analysis indicated that the initial oxide on the surface of Cu nanoparticles was completely removed, and formate was generated as a by-product which could decompose at low temperature. According to the thermal analysis results, it was found that the sintering temperature of Cu nanoparticles with formic acid pretreatment was reduced to 160 °C. And the corresponding microstructures further demonstrated that the emerging small exothermic peak of thermal curve over the temperature range between 120 and 160 °C was caused by the formation of sintering necks. The formic acid treated Cu nanoparticle films sintered at 260 and 320 °C exhibited an electrical resistivity of 6.1 and 3.6 μΩ cm respectively.
 A1  - u, J i n g d o n g   L i
 A1  - i, H o n g j u n   J
@@ -1596,7 +1596,7 @@ PB  - Pleiades Publishing
 SN  - 1608-3156
 DO  - 10.1134/S0018151X18040156
 M3  - 10.1134/S0018151X18040156
-UR  - http://dx.doi.org/10.1134/S0018151X18040156
+UR  - https://doi.org/10.1134/S0018151X18040156
 N2  - In this study, we present a new simple method using formic acid pretreatment to achieve low temperature sintering of Cu nanoparticles, and the Cu nanoparticles have been successfully prepared with a modified polyol method. For formic acid pretreatment, the spherical Cu nanoparticles with an average size of 30 nm were saturated with a mixed solution of formic acid and absolute ethanol directly. The surface composition analysis indicated that the initial oxide on the surface of Cu nanoparticles was completely removed, and formate was generated as a by-product which could decompose at low temperature. According to the thermal analysis results, it was found that the sintering temperature of Cu nanoparticles with formic acid pretreatment was reduced to 160 °C. And the corresponding microstructures further demonstrated that the emerging small exothermic peak of thermal curve over the temperature range between 120 and 160 °C was caused by the formation of sintering necks. The formic acid treated Cu nanoparticle films sintered at 260 and 320 °C exhibited an electrical resistivity of 6.1 and 3.6 μΩ cm respectively.
 A1  - y, S .   A .   R o m a s h e v s k i
 A1  - v, S .   I .   A s h i t k o
@@ -1617,7 +1617,7 @@ PB  - Springer Netherlands
 SN  - 1879-5447
 DO  - 10.1007/s13246-016-0494-2
 M3  - 10.1007/s13246-016-0494-2
-UR  - http://dx.doi.org/10.1007/s13246-016-0494-2
+UR  - https://doi.org/10.1007/s13246-016-0494-2
 N2  - In this study, we present a new simple method using formic acid pretreatment to achieve low temperature sintering of Cu nanoparticles, and the Cu nanoparticles have been successfully prepared with a modified polyol method. For formic acid pretreatment, the spherical Cu nanoparticles with an average size of 30 nm were saturated with a mixed solution of formic acid and absolute ethanol directly. The surface composition analysis indicated that the initial oxide on the surface of Cu nanoparticles was completely removed, and formate was generated as a by-product which could decompose at low temperature. According to the thermal analysis results, it was found that the sintering temperature of Cu nanoparticles with formic acid pretreatment was reduced to 160 °C. And the corresponding microstructures further demonstrated that the emerging small exothermic peak of thermal curve over the temperature range between 120 and 160 °C was caused by the formation of sintering necks. The formic acid treated Cu nanoparticle films sintered at 260 and 320 °C exhibited an electrical resistivity of 6.1 and 3.6 μΩ cm respectively.
 ER  - 
 
@@ -1635,7 +1635,7 @@ PB  - Springer US
 SN  - 1573-482X
 DO  - 10.1007/s10854-015-2725-9
 M3  - 10.1007/s10854-015-2725-9
-UR  - http://dx.doi.org/10.1007/s10854-015-2725-9
+UR  - https://doi.org/10.1007/s10854-015-2725-9
 N2  - In this study, we present a new simple method using formic acid pretreatment to achieve low temperature sintering of Cu nanoparticles, and the Cu nanoparticles have been successfully prepared with a modified polyol method. For formic acid pretreatment, the spherical Cu nanoparticles with an average size of 30 nm were saturated with a mixed solution of formic acid and absolute ethanol directly. The surface composition analysis indicated that the initial oxide on the surface of Cu nanoparticles was completely removed, and formate was generated as a by-product which could decompose at low temperature. According to the thermal analysis results, it was found that the sintering temperature of Cu nanoparticles with formic acid pretreatment was reduced to 160 °C. And the corresponding microstructures further demonstrated that the emerging small exothermic peak of thermal curve over the temperature range between 120 and 160 °C was caused by the formation of sintering necks. The formic acid treated Cu nanoparticle films sintered at 260 and 320 °C exhibited an electrical resistivity of 6.1 and 3.6 μΩ cm respectively.
 A1  - r, F .   A k b a
 A1  - z, M .   K o l a h d o u
@@ -1658,7 +1658,7 @@ PB  - Springer US
 SN  - 1573-482X
 DO  - 10.1007/s10854-018-0053-6
 M3  - 10.1007/s10854-018-0053-6
-UR  - http://dx.doi.org/10.1007/s10854-018-0053-6
+UR  - https://doi.org/10.1007/s10854-018-0053-6
 N2  - This paper presents fabrication methods for some Multi Walled Carbon Nano Tube (MWCNT)/epoxy composites. These nanocomposite are characterized with respect to temperature and strain. The effect of parameters such as sonication time, percolation threshold, film thickness, use of substrate and formation of electric contact have been observed. These nanocomposites are fabricated: (i) with mould without substrate, (ii) without mould on poly ethylene terephthalate substrate, (iii) without mould without substrate and (iv) without mould without substrate with embedded electrode wire. Field Emission Scanning Electron Microscope of these samples is done to measure the dispersion and agglomerates formation of CNT bundles into polymer matrices. Piezoresistive characterization of these samples with respect to temperature and strain is performed. This paper gives a novel strategy for fabricating a highly sensitive MWCNT/epoxy strain sensor with excellent repeatability.
 A1  - a, G a u r a v   S a p r
 A1  - r, P a r v e e n   K u m a
@@ -1681,7 +1681,7 @@ PB  - Springer-Verlag
 SN  - 1618-2650
 DO  - 10.1007/s00216-013-6748-x
 M3  - 10.1007/s00216-013-6748-x
-UR  - http://dx.doi.org/10.1007/s00216-013-6748-x
+UR  - https://doi.org/10.1007/s00216-013-6748-x
 N2  - This paper presents fabrication methods for some Multi Walled Carbon Nano Tube (MWCNT)/epoxy composites. These nanocomposite are characterized with respect to temperature and strain. The effect of parameters such as sonication time, percolation threshold, film thickness, use of substrate and formation of electric contact have been observed. These nanocomposites are fabricated: (i) with mould without substrate, (ii) without mould on poly ethylene terephthalate substrate, (iii) without mould without substrate and (iv) without mould without substrate with embedded electrode wire. Field Emission Scanning Electron Microscope of these samples is done to measure the dispersion and agglomerates formation of CNT bundles into polymer matrices. Piezoresistive characterization of these samples with respect to temperature and strain is performed. This paper gives a novel strategy for fabricating a highly sensitive MWCNT/epoxy strain sensor with excellent repeatability.
 A1  - s, F r a n k   M e i n e r
 A1  - g, I n k a   P l e t t e n b e r
@@ -1706,7 +1706,7 @@ PB  - Springer US
 SN  - 1544-1016
 DO  - 10.1007/s11666-018-0758-3
 M3  - 10.1007/s11666-018-0758-3
-UR  - http://dx.doi.org/10.1007/s11666-018-0758-3
+UR  - https://doi.org/10.1007/s11666-018-0758-3
 N2  - As a result of the rise in processing power demands of today’s personal computers, water-cooled pin fin heat sinks are increasingly being employed for the cooling of graphical processing units. Currently, these high-performance devices are manufactured through high-cost, high-waste processes. In recent years, a new solution has emerged using the cold gas dynamic spray process, in which pin fins are manufactured onto a base plate by spraying metallic powder particles through a mask allowing for a high degree of adaptability to different graphics processing unit shapes and sizes. One drawback of this process is reduced deposition efficiency, resulting in a fair portion of the feedstock powder being wasted as substrate sensitivity to heat and mechanical residual stresses requires the use of reduced spray parameters. This work aims to demonstrate the feasibility of using powder recycling to mitigate this issue and compares coatings sprayed with reclaimed powder to their counterparts sprayed with as-received powder. The work demonstrates that cold gas dynamic spray is a highly flexible and economically competitive process for the production of pin fin heat sinks when using powder recycling. The heat transfer properties of the resulting fins are briefly addressed and demonstrated.
 A1  - y, J .   P e r r
 A1  - r, P .   R i c h e
@@ -1728,7 +1728,7 @@ PB  - Springer Vienna
 SN  - 1436-5073
 DO  - 10.1007/s00604-016-2007-0
 M3  - 10.1007/s00604-016-2007-0
-UR  - http://dx.doi.org/10.1007/s00604-016-2007-0
+UR  - https://doi.org/10.1007/s00604-016-2007-0
 N2  - Functionalized nanocomposites based on various type of graphene nanomaterials including graphene, graphene oxides (GOs), and doped graphene (oxides) are widely used as materials for various sensors that can display high sensitivity, selectivity and stability. This review with 347 references summarizes advances in the preparation and functionalization of graphene nanocomposites for the application of electrochemical sensors and biosensors. Following a general introduction into the field, the article is divided into subsections on (a) the synthesis and functionalization of nanocomposites (made from graphene, various kinds of GOs, heteroatom-doped GOs), (b) on methods for functionalization of composites (with other carbon nanomaterials, metal nanoparticles, metal oxide and metal sulfide nanoparticles), (c) on functionalization with inorganic materials including polyoxometalates, hexacyanoferrates, minerals), (d) on functionalization with organic materials such as amino acids, surfactants, organic dyes, ionic liquids, macrocycles (including cyclodextrins, crown ethers and calixarenes), and (e) on functionalization with organometallics and with various other organic compounds, (f) on functionalizations with polymers such as conventional polymers, polyelectrolytes, conducting polymers, molecularly imprinted polymers, (g) on functionalization with biomolecules including proteins and nucleic acids. Other subsections cover flexible graphene and GO based nanocomposites and 3D composites. Application of graphene and GO nanocomposites are then covered in a in large section that comprises electrochemical sensors and biosensors (based on voltammetry, amperometry, potentiometry, impedimetry, electrochemiluminescence, photoelectrochemistry, field effect transistors, electrochemical immunosensors) with specific subsections on gas sensors, enzymatic biosensors and gene sensors. A concluding section covers current challenges and perspectives of graphene and GO based (bio)sensing.
 A1  - u, J u n h u i   X
 A1  - g, Y a z h e n   W a n
@@ -1749,7 +1749,7 @@ PB  - Springer US
 SN  - 1525-1497
 DO  - 10.1007/s11606-014-2834-9
 M3  - 10.1007/s11606-014-2834-9
-UR  - http://dx.doi.org/10.1007/s11606-014-2834-9
+UR  - https://doi.org/10.1007/s11606-014-2834-9
 N2  - Functionalized nanocomposites based on various type of graphene nanomaterials including graphene, graphene oxides (GOs), and doped graphene (oxides) are widely used as materials for various sensors that can display high sensitivity, selectivity and stability. This review with 347 references summarizes advances in the preparation and functionalization of graphene nanocomposites for the application of electrochemical sensors and biosensors. Following a general introduction into the field, the article is divided into subsections on (a) the synthesis and functionalization of nanocomposites (made from graphene, various kinds of GOs, heteroatom-doped GOs), (b) on methods for functionalization of composites (with other carbon nanomaterials, metal nanoparticles, metal oxide and metal sulfide nanoparticles), (c) on functionalization with inorganic materials including polyoxometalates, hexacyanoferrates, minerals), (d) on functionalization with organic materials such as amino acids, surfactants, organic dyes, ionic liquids, macrocycles (including cyclodextrins, crown ethers and calixarenes), and (e) on functionalization with organometallics and with various other organic compounds, (f) on functionalizations with polymers such as conventional polymers, polyelectrolytes, conducting polymers, molecularly imprinted polymers, (g) on functionalization with biomolecules including proteins and nucleic acids. Other subsections cover flexible graphene and GO based nanocomposites and 3D composites. Application of graphene and GO nanocomposites are then covered in a in large section that comprises electrochemical sensors and biosensors (based on voltammetry, amperometry, potentiometry, impedimetry, electrochemiluminescence, photoelectrochemistry, field effect transistors, electrochemical immunosensors) with specific subsections on gas sensors, enzymatic biosensors and gene sensors. A concluding section covers current challenges and perspectives of graphene and GO based (bio)sensing.
 ER  - 
 
@@ -1767,7 +1767,7 @@ PB  - Springer-Verlag
 SN  - 1432-0428
 DO  - 10.1007/s00125-012-2688-9
 M3  - 10.1007/s00125-012-2688-9
-UR  - http://dx.doi.org/10.1007/s00125-012-2688-9
+UR  - https://doi.org/10.1007/s00125-012-2688-9
 N2  - Functionalized nanocomposites based on various type of graphene nanomaterials including graphene, graphene oxides (GOs), and doped graphene (oxides) are widely used as materials for various sensors that can display high sensitivity, selectivity and stability. This review with 347 references summarizes advances in the preparation and functionalization of graphene nanocomposites for the application of electrochemical sensors and biosensors. Following a general introduction into the field, the article is divided into subsections on (a) the synthesis and functionalization of nanocomposites (made from graphene, various kinds of GOs, heteroatom-doped GOs), (b) on methods for functionalization of composites (with other carbon nanomaterials, metal nanoparticles, metal oxide and metal sulfide nanoparticles), (c) on functionalization with inorganic materials including polyoxometalates, hexacyanoferrates, minerals), (d) on functionalization with organic materials such as amino acids, surfactants, organic dyes, ionic liquids, macrocycles (including cyclodextrins, crown ethers and calixarenes), and (e) on functionalization with organometallics and with various other organic compounds, (f) on functionalizations with polymers such as conventional polymers, polyelectrolytes, conducting polymers, molecularly imprinted polymers, (g) on functionalization with biomolecules including proteins and nucleic acids. Other subsections cover flexible graphene and GO based nanocomposites and 3D composites. Application of graphene and GO nanocomposites are then covered in a in large section that comprises electrochemical sensors and biosensors (based on voltammetry, amperometry, potentiometry, impedimetry, electrochemiluminescence, photoelectrochemistry, field effect transistors, electrochemical immunosensors) with specific subsections on gas sensors, enzymatic biosensors and gene sensors. A concluding section covers current challenges and perspectives of graphene and GO based (bio)sensing.
 ER  - 
 
@@ -1785,7 +1785,7 @@ PB  - Springer Netherlands
 SN  - 1879-5447
 DO  - 10.1007/s13246-010-0012-x
 M3  - 10.1007/s13246-010-0012-x
-UR  - http://dx.doi.org/10.1007/s13246-010-0012-x
+UR  - https://doi.org/10.1007/s13246-010-0012-x
 N2  - Functionalized nanocomposites based on various type of graphene nanomaterials including graphene, graphene oxides (GOs), and doped graphene (oxides) are widely used as materials for various sensors that can display high sensitivity, selectivity and stability. This review with 347 references summarizes advances in the preparation and functionalization of graphene nanocomposites for the application of electrochemical sensors and biosensors. Following a general introduction into the field, the article is divided into subsections on (a) the synthesis and functionalization of nanocomposites (made from graphene, various kinds of GOs, heteroatom-doped GOs), (b) on methods for functionalization of composites (with other carbon nanomaterials, metal nanoparticles, metal oxide and metal sulfide nanoparticles), (c) on functionalization with inorganic materials including polyoxometalates, hexacyanoferrates, minerals), (d) on functionalization with organic materials such as amino acids, surfactants, organic dyes, ionic liquids, macrocycles (including cyclodextrins, crown ethers and calixarenes), and (e) on functionalization with organometallics and with various other organic compounds, (f) on functionalizations with polymers such as conventional polymers, polyelectrolytes, conducting polymers, molecularly imprinted polymers, (g) on functionalization with biomolecules including proteins and nucleic acids. Other subsections cover flexible graphene and GO based nanocomposites and 3D composites. Application of graphene and GO nanocomposites are then covered in a in large section that comprises electrochemical sensors and biosensors (based on voltammetry, amperometry, potentiometry, impedimetry, electrochemiluminescence, photoelectrochemistry, field effect transistors, electrochemical immunosensors) with specific subsections on gas sensors, enzymatic biosensors and gene sensors. A concluding section covers current challenges and perspectives of graphene and GO based (bio)sensing.
 ER  - 
 
@@ -1803,7 +1803,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 2190-5444
 DO  - 10.1140/epjp/i2018-11973-4
 M3  - 10.1140/epjp/i2018-11973-4
-UR  - http://dx.doi.org/10.1140/epjp/i2018-11973-4
+UR  - https://doi.org/10.1140/epjp/i2018-11973-4
 N2  - Functionalized nanocomposites based on various type of graphene nanomaterials including graphene, graphene oxides (GOs), and doped graphene (oxides) are widely used as materials for various sensors that can display high sensitivity, selectivity and stability. This review with 347 references summarizes advances in the preparation and functionalization of graphene nanocomposites for the application of electrochemical sensors and biosensors. Following a general introduction into the field, the article is divided into subsections on (a) the synthesis and functionalization of nanocomposites (made from graphene, various kinds of GOs, heteroatom-doped GOs), (b) on methods for functionalization of composites (with other carbon nanomaterials, metal nanoparticles, metal oxide and metal sulfide nanoparticles), (c) on functionalization with inorganic materials including polyoxometalates, hexacyanoferrates, minerals), (d) on functionalization with organic materials such as amino acids, surfactants, organic dyes, ionic liquids, macrocycles (including cyclodextrins, crown ethers and calixarenes), and (e) on functionalization with organometallics and with various other organic compounds, (f) on functionalizations with polymers such as conventional polymers, polyelectrolytes, conducting polymers, molecularly imprinted polymers, (g) on functionalization with biomolecules including proteins and nucleic acids. Other subsections cover flexible graphene and GO based nanocomposites and 3D composites. Application of graphene and GO nanocomposites are then covered in a in large section that comprises electrochemical sensors and biosensors (based on voltammetry, amperometry, potentiometry, impedimetry, electrochemiluminescence, photoelectrochemistry, field effect transistors, electrochemical immunosensors) with specific subsections on gas sensors, enzymatic biosensors and gene sensors. A concluding section covers current challenges and perspectives of graphene and GO based (bio)sensing.
 A1  - h, C .   E .   A a l s e t
 A1  - i, F .   A c e r b
@@ -2108,7 +2108,7 @@ PB  - Science China Press
 SN  - 1869-1900
 DO  - 10.1007/s11431-016-6056-8
 M3  - 10.1007/s11431-016-6056-8
-UR  - http://dx.doi.org/10.1007/s11431-016-6056-8
+UR  - https://doi.org/10.1007/s11431-016-6056-8
 N2  - Functionalized nanocomposites based on various type of graphene nanomaterials including graphene, graphene oxides (GOs), and doped graphene (oxides) are widely used as materials for various sensors that can display high sensitivity, selectivity and stability. This review with 347 references summarizes advances in the preparation and functionalization of graphene nanocomposites for the application of electrochemical sensors and biosensors. Following a general introduction into the field, the article is divided into subsections on (a) the synthesis and functionalization of nanocomposites (made from graphene, various kinds of GOs, heteroatom-doped GOs), (b) on methods for functionalization of composites (with other carbon nanomaterials, metal nanoparticles, metal oxide and metal sulfide nanoparticles), (c) on functionalization with inorganic materials including polyoxometalates, hexacyanoferrates, minerals), (d) on functionalization with organic materials such as amino acids, surfactants, organic dyes, ionic liquids, macrocycles (including cyclodextrins, crown ethers and calixarenes), and (e) on functionalization with organometallics and with various other organic compounds, (f) on functionalizations with polymers such as conventional polymers, polyelectrolytes, conducting polymers, molecularly imprinted polymers, (g) on functionalization with biomolecules including proteins and nucleic acids. Other subsections cover flexible graphene and GO based nanocomposites and 3D composites. Application of graphene and GO nanocomposites are then covered in a in large section that comprises electrochemical sensors and biosensors (based on voltammetry, amperometry, potentiometry, impedimetry, electrochemiluminescence, photoelectrochemistry, field effect transistors, electrochemical immunosensors) with specific subsections on gas sensors, enzymatic biosensors and gene sensors. A concluding section covers current challenges and perspectives of graphene and GO based (bio)sensing.
 A1  - g, R u i   F a n
 A1  - g, W e n J u n   Z h a n
@@ -2130,7 +2130,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2005-4602
 DO  - 10.1007/s12541-018-0136-6
 M3  - 10.1007/s12541-018-0136-6
-UR  - http://dx.doi.org/10.1007/s12541-018-0136-6
+UR  - https://doi.org/10.1007/s12541-018-0136-6
 N2  - Functionalized nanocomposites based on various type of graphene nanomaterials including graphene, graphene oxides (GOs), and doped graphene (oxides) are widely used as materials for various sensors that can display high sensitivity, selectivity and stability. This review with 347 references summarizes advances in the preparation and functionalization of graphene nanocomposites for the application of electrochemical sensors and biosensors. Following a general introduction into the field, the article is divided into subsections on (a) the synthesis and functionalization of nanocomposites (made from graphene, various kinds of GOs, heteroatom-doped GOs), (b) on methods for functionalization of composites (with other carbon nanomaterials, metal nanoparticles, metal oxide and metal sulfide nanoparticles), (c) on functionalization with inorganic materials including polyoxometalates, hexacyanoferrates, minerals), (d) on functionalization with organic materials such as amino acids, surfactants, organic dyes, ionic liquids, macrocycles (including cyclodextrins, crown ethers and calixarenes), and (e) on functionalization with organometallics and with various other organic compounds, (f) on functionalizations with polymers such as conventional polymers, polyelectrolytes, conducting polymers, molecularly imprinted polymers, (g) on functionalization with biomolecules including proteins and nucleic acids. Other subsections cover flexible graphene and GO based nanocomposites and 3D composites. Application of graphene and GO nanocomposites are then covered in a in large section that comprises electrochemical sensors and biosensors (based on voltammetry, amperometry, potentiometry, impedimetry, electrochemiluminescence, photoelectrochemistry, field effect transistors, electrochemical immunosensors) with specific subsections on gas sensors, enzymatic biosensors and gene sensors. A concluding section covers current challenges and perspectives of graphene and GO based (bio)sensing.
 A1  - e, J o n g s u   L e
 A1  - e, C h a n g w o o   L e
@@ -2150,7 +2150,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1432-0630
 DO  - 10.1007/s00339-016-9718-2
 M3  - 10.1007/s00339-016-9718-2
-UR  - http://dx.doi.org/10.1007/s00339-016-9718-2
+UR  - https://doi.org/10.1007/s00339-016-9718-2
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 A1  - o, Y u   Z h a
 A1  - o, F a z h i   L u
@@ -2174,7 +2174,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1432-0428
 DO  - 10.1007/s00125-013-3012-z
 M3  - 10.1007/s00125-013-3012-z
-UR  - http://dx.doi.org/10.1007/s00125-013-3012-z
+UR  - https://doi.org/10.1007/s00125-013-3012-z
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 ER  - 
 
@@ -2192,7 +2192,7 @@ PB  - Springer Netherlands
 SN  - 1879-5447
 DO  - 10.1007/s13246-014-0248-y
 M3  - 10.1007/s13246-014-0248-y
-UR  - http://dx.doi.org/10.1007/s13246-014-0248-y
+UR  - https://doi.org/10.1007/s13246-014-0248-y
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 ER  - 
 
@@ -2210,7 +2210,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2005-4602
 DO  - 10.1007/s12541-015-0133-y
 M3  - 10.1007/s12541-015-0133-y
-UR  - http://dx.doi.org/10.1007/s12541-015-0133-y
+UR  - https://doi.org/10.1007/s12541-015-0133-y
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 A1  - g, S e u n g k y u   Y a n
 A1  - m, H y u n g s u b   K i
@@ -2233,7 +2233,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1869-4101
 DO  - 10.1007/s13244-015-0387-z
 M3  - 10.1007/s13244-015-0387-z
-UR  - http://dx.doi.org/10.1007/s13244-015-0387-z
+UR  - https://doi.org/10.1007/s13244-015-0387-z
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 ER  - 
 
@@ -2251,7 +2251,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1434-6079
 DO  - 10.1140/epjd/e2013-40420-y
 M3  - 10.1140/epjd/e2013-40420-y
-UR  - http://dx.doi.org/10.1140/epjd/e2013-40420-y
+UR  - https://doi.org/10.1140/epjd/e2013-40420-y
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 A1  - t, R ü d i g e r   F o e s
 A1  - t, M a r t i n   S c h m i d
@@ -2272,7 +2272,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-018-2207-5
 M3  - 10.1007/s12274-018-2207-5
-UR  - http://dx.doi.org/10.1007/s12274-018-2207-5
+UR  - https://doi.org/10.1007/s12274-018-2207-5
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 A1  - r, D e e p a k   K u k k a
 A1  - i, K o w s a l y a   V e l l i n g i r
@@ -2296,7 +2296,7 @@ PB  - The Korean Institute of Metals and Materials
 SN  - 2093-6788
 DO  - 10.1007/s13391-011-0601-1
 M3  - 10.1007/s13391-011-0601-1
-UR  - http://dx.doi.org/10.1007/s13391-011-0601-1
+UR  - https://doi.org/10.1007/s13391-011-0601-1
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 A1  - g, K i h y o n   H o n
 A1  - e, J o n g - L a m   L e
@@ -2316,7 +2316,7 @@ PB  - Chinese Chemical Society and Institute of Chemistry, CAS
 SN  - 1439-6203
 DO  - 10.1007/s10118-019-2173-8
 M3  - 10.1007/s10118-019-2173-8
-UR  - http://dx.doi.org/10.1007/s10118-019-2173-8
+UR  - https://doi.org/10.1007/s10118-019-2173-8
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 A1  - g, Z h e n - H e   W a n
 A1  - n, X i n g   C h e
@@ -2339,7 +2339,7 @@ PB  - Springer US
 SN  - 1525-1497
 DO  - 10.1007/s11606-015-3271-0
 M3  - 10.1007/s11606-015-3271-0
-UR  - http://dx.doi.org/10.1007/s11606-015-3271-0
+UR  - https://doi.org/10.1007/s11606-015-3271-0
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 ER  - 
 
@@ -2357,7 +2357,7 @@ PB  - Science China Press
 SN  - 1869-1927
 DO  - 10.1007/s11433-018-9239-9
 M3  - 10.1007/s11433-018-9239-9
-UR  - http://dx.doi.org/10.1007/s11433-018-9239-9
+UR  - https://doi.org/10.1007/s11433-018-9239-9
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 A1  - u, J i a n Q i a o   H
 A1  - i, R u i   L
@@ -2379,7 +2379,7 @@ PB  - Springer US
 SN  - 1879-1123
 DO  - 10.1007/s13361-015-1158-2
 M3  - 10.1007/s13361-015-1158-2
-UR  - http://dx.doi.org/10.1007/s13361-015-1158-2
+UR  - https://doi.org/10.1007/s13361-015-1158-2
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 ER  - 
 
@@ -2397,7 +2397,7 @@ PB  - The Korean Institute of Metals and Materials
 SN  - 2093-6788
 DO  - 10.1007/s13391-011-0901-5
 M3  - 10.1007/s13391-011-0901-5
-UR  - http://dx.doi.org/10.1007/s13391-011-0901-5
+UR  - https://doi.org/10.1007/s13391-011-0901-5
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 A1  - e, J a n g - S i k   L e
 ER  - 
@@ -2416,7 +2416,7 @@ PB  - Springer-Verlag
 SN  - 1618-2650
 DO  - 10.1007/s00216-011-5631-x
 M3  - 10.1007/s00216-011-5631-x
-UR  - http://dx.doi.org/10.1007/s00216-011-5631-x
+UR  - https://doi.org/10.1007/s00216-011-5631-x
 N2  - CuInS2 (CIS) nanostructure thin films were successfully synthesized on FTO conductive glass substrates by solvothermal method. It is found that the surface morphology and microstructure of CIS thin films can be tailored by simply adjusting the concentration of oxalic acid. CIS nanostructure films with texture of “nanosheet array” and “flower-like microsphere” were obtained and used as Pt-free counter electrode for dye-sensitized solar cells (DSSCs). The nanosheet array CIS was found to have a better electrocatalytic activity than the flower-like microsphere one. DSSCs based on nanosheet array CIS thin film counter electrode show conversion efficiency of 3.33 %, which is comparable to the Pt-catalyzed DSSCs. The easy synthesis, low cost, morphology tunable and excellent electrocatalytic property may make the CuInS2 nanostructure competitive as counter electrode in DSSCs.
 A1  - a, D a n a   C i a l l
 A1  - z, A n n e   M ä r
@@ -2441,7 +2441,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1735-2630
 DO  - 10.1007/s13762-018-1857-x
 M3  - 10.1007/s13762-018-1857-x
-UR  - http://dx.doi.org/10.1007/s13762-018-1857-x
+UR  - https://doi.org/10.1007/s13762-018-1857-x
 N2  - This review focuses on the investigation and development of various support materials in TiO2 photocatalyst system with special emphasis on the photodecolorization of synthetic dyes. Efforts have been devoted to find suitable support material of TiO2 for improving its recovery efficiency and adsorption capability. The relationship between the structural characteristics and physicochemical reactivity properties of the supported TiO2 photocatalysis has been highlighted. The vicinity of photocatalysis and support system significantly accelerated the transfer step between adsorption and overall oxidative of decolorization process. Comparison of the photodecolorization with several synthetic dyes has been made and concluded that the photocatalytic activities have been influenced by the structural and surface properties of the photocatalyst.
 A1  - n, M .   A .   M o h d   A d n a
 A1  - i, N .   M u h d   J u l k a p l
@@ -2463,7 +2463,7 @@ PB  - Springer US
 SN  - 1860-2002
 DO  - 10.1007/s11307-017-1139-x
 M3  - 10.1007/s11307-017-1139-x
-UR  - http://dx.doi.org/10.1007/s11307-017-1139-x
+UR  - https://doi.org/10.1007/s11307-017-1139-x
 N2  - This review focuses on the investigation and development of various support materials in TiO2 photocatalyst system with special emphasis on the photodecolorization of synthetic dyes. Efforts have been devoted to find suitable support material of TiO2 for improving its recovery efficiency and adsorption capability. The relationship between the structural characteristics and physicochemical reactivity properties of the supported TiO2 photocatalysis has been highlighted. The vicinity of photocatalysis and support system significantly accelerated the transfer step between adsorption and overall oxidative of decolorization process. Comparison of the photodecolorization with several synthetic dyes has been made and concluded that the photocatalytic activities have been influenced by the structural and surface properties of the photocatalyst.
 ER  - 
 
@@ -2481,7 +2481,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1434-6052
 DO  - 10.1140/epjc/s10052-018-5812-2
 M3  - 10.1140/epjc/s10052-018-5812-2
-UR  - http://dx.doi.org/10.1140/epjc/s10052-018-5812-2
+UR  - https://doi.org/10.1140/epjc/s10052-018-5812-2
 N2  - The Gerda collaboration is performing a sensitive search for neutrinoless double beta decay of \(^{76}\hbox {Ge}\) at the INFN Laboratori Nazionali del Gran Sasso, Italy. The upgrade of the Gerda experiment from Phase I to Phase II has been concluded in December 2015. The first Phase II data release shows that the goal to suppress the background by one order of magnitude compared to Phase I has been achieved. Gerda is thus the first experiment that will remain “background-free” up to its design exposure (\(\hbox {100 kg}~\hbox {year}\)). It will reach thereby a half-life sensitivity of more than \(10^{26}\) year within 3 years of data collection. This paper describes in detail the modifications and improvements of the experimental setup for Phase II and discusses the performance of individual detector components.
 A1  - n, G E R D A   C o l l a b o r a t i o
 A1  - i, M .   A g o s t i n
@@ -2614,7 +2614,7 @@ PB  - Springer London
 SN  - 1433-3015
 DO  - 10.1007/s00170-015-8119-6
 M3  - 10.1007/s00170-015-8119-6
-UR  - http://dx.doi.org/10.1007/s00170-015-8119-6
+UR  - https://doi.org/10.1007/s00170-015-8119-6
 N2  - The Gerda collaboration is performing a sensitive search for neutrinoless double beta decay of \(^{76}\hbox {Ge}\) at the INFN Laboratori Nazionali del Gran Sasso, Italy. The upgrade of the Gerda experiment from Phase I to Phase II has been concluded in December 2015. The first Phase II data release shows that the goal to suppress the background by one order of magnitude compared to Phase I has been achieved. Gerda is thus the first experiment that will remain “background-free” up to its design exposure (\(\hbox {100 kg}~\hbox {year}\)). It will reach thereby a half-life sensitivity of more than \(10^{26}\) year within 3 years of data collection. This paper describes in detail the modifications and improvements of the experimental setup for Phase II and discusses the performance of individual detector components.
 A1  - d, A b d   E l   K h a l i c k   M o h a m m a
 A1  - g, D a n w e i   W a n
@@ -2634,7 +2634,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 2150-5551
 DO  - 10.1007/s40820-018-0189-1
 M3  - 10.1007/s40820-018-0189-1
-UR  - http://dx.doi.org/10.1007/s40820-018-0189-1
+UR  - https://doi.org/10.1007/s40820-018-0189-1
 N2  - The Gerda collaboration is performing a sensitive search for neutrinoless double beta decay of \(^{76}\hbox {Ge}\) at the INFN Laboratori Nazionali del Gran Sasso, Italy. The upgrade of the Gerda experiment from Phase I to Phase II has been concluded in December 2015. The first Phase II data release shows that the goal to suppress the background by one order of magnitude compared to Phase I has been achieved. Gerda is thus the first experiment that will remain “background-free” up to its design exposure (\(\hbox {100 kg}~\hbox {year}\)). It will reach thereby a half-life sensitivity of more than \(10^{26}\) year within 3 years of data collection. This paper describes in detail the modifications and improvements of the experimental setup for Phase II and discusses the performance of individual detector components.
 A1  - w, R i b u   M a t h e
 A1  - r, A .   R a v i   S a n k a
@@ -2654,7 +2654,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 2191-4281
 DO  - 10.1007/s13369-017-2491-5
 M3  - 10.1007/s13369-017-2491-5
-UR  - http://dx.doi.org/10.1007/s13369-017-2491-5
+UR  - https://doi.org/10.1007/s13369-017-2491-5
 N2  - The desire of flexibility, light weight and low cost in current electronic device has increased the application of flexible printed circuit board (FPCB). This paper aims to investigate the effect of different Reynolds number (Re) toward FPCB attached with ball grid array (BGA) package in different arrangements. Actual BGA package with 100 solder joints incorporating FPCB was attached to a fixture in wind tunnel test section to perform FPCB’s deflection analysis with different flow velocities and package’s configurations. Furthermore, numerical simulation was also performed to obtain numerical deflection and stress value. The findings show that the Reynolds numbers have a substantial effect to the FPCB’s deflection and stress. However, the BGA package’s positions on the FPCB were found to be insignificant to the responses. The actual BGA package on FPCB as presented in this paper will represent more realistic values of determined FPCB’s deflection and stress.
 A1  - m, C .   H .   L i
 A1  - h, M .   Z .   A b d u l l a
@@ -2676,7 +2676,7 @@ PB  - Springer-Verlag
 SN  - 1619-7089
 DO  - 10.1007/s00259-011-1911-0
 M3  - 10.1007/s00259-011-1911-0
-UR  - http://dx.doi.org/10.1007/s00259-011-1911-0
+UR  - https://doi.org/10.1007/s00259-011-1911-0
 N2  - The desire of flexibility, light weight and low cost in current electronic device has increased the application of flexible printed circuit board (FPCB). This paper aims to investigate the effect of different Reynolds number (Re) toward FPCB attached with ball grid array (BGA) package in different arrangements. Actual BGA package with 100 solder joints incorporating FPCB was attached to a fixture in wind tunnel test section to perform FPCB’s deflection analysis with different flow velocities and package’s configurations. Furthermore, numerical simulation was also performed to obtain numerical deflection and stress value. The findings show that the Reynolds numbers have a substantial effect to the FPCB’s deflection and stress. However, the BGA package’s positions on the FPCB were found to be insignificant to the responses. The actual BGA package on FPCB as presented in this paper will represent more realistic values of determined FPCB’s deflection and stress.
 ER  - 
 
@@ -2694,7 +2694,7 @@ PB  - Springer-Verlag
 SN  - 1432-0428
 DO  - 10.1007/s00125-011-2276-4
 M3  - 10.1007/s00125-011-2276-4
-UR  - http://dx.doi.org/10.1007/s00125-011-2276-4
+UR  - https://doi.org/10.1007/s00125-011-2276-4
 N2  - The desire of flexibility, light weight and low cost in current electronic device has increased the application of flexible printed circuit board (FPCB). This paper aims to investigate the effect of different Reynolds number (Re) toward FPCB attached with ball grid array (BGA) package in different arrangements. Actual BGA package with 100 solder joints incorporating FPCB was attached to a fixture in wind tunnel test section to perform FPCB’s deflection analysis with different flow velocities and package’s configurations. Furthermore, numerical simulation was also performed to obtain numerical deflection and stress value. The findings show that the Reynolds numbers have a substantial effect to the FPCB’s deflection and stress. However, the BGA package’s positions on the FPCB were found to be insignificant to the responses. The actual BGA package on FPCB as presented in this paper will represent more realistic values of determined FPCB’s deflection and stress.
 ER  - 
 
@@ -2712,7 +2712,7 @@ PB  - Springer-Verlag
 SN  - 1432-0630
 DO  - 10.1007/s00339-011-6604-9
 M3  - 10.1007/s00339-011-6604-9
-UR  - http://dx.doi.org/10.1007/s00339-011-6604-9
+UR  - https://doi.org/10.1007/s00339-011-6604-9
 N2  - The desire of flexibility, light weight and low cost in current electronic device has increased the application of flexible printed circuit board (FPCB). This paper aims to investigate the effect of different Reynolds number (Re) toward FPCB attached with ball grid array (BGA) package in different arrangements. Actual BGA package with 100 solder joints incorporating FPCB was attached to a fixture in wind tunnel test section to perform FPCB’s deflection analysis with different flow velocities and package’s configurations. Furthermore, numerical simulation was also performed to obtain numerical deflection and stress value. The findings show that the Reynolds numbers have a substantial effect to the FPCB’s deflection and stress. However, the BGA package’s positions on the FPCB were found to be insignificant to the responses. The actual BGA package on FPCB as presented in this paper will represent more realistic values of determined FPCB’s deflection and stress.
 A1  - k, H e e   K .   P a r
 A1  - r, K e n n e t h   E .   S c h r i v e
@@ -2733,7 +2733,7 @@ PB  - Springer Netherlands
 SN  - 1879-5447
 DO  - 10.1007/s13246-011-0056-6
 M3  - 10.1007/s13246-011-0056-6
-UR  - http://dx.doi.org/10.1007/s13246-011-0056-6
+UR  - https://doi.org/10.1007/s13246-011-0056-6
 N2  - The desire of flexibility, light weight and low cost in current electronic device has increased the application of flexible printed circuit board (FPCB). This paper aims to investigate the effect of different Reynolds number (Re) toward FPCB attached with ball grid array (BGA) package in different arrangements. Actual BGA package with 100 solder joints incorporating FPCB was attached to a fixture in wind tunnel test section to perform FPCB’s deflection analysis with different flow velocities and package’s configurations. Furthermore, numerical simulation was also performed to obtain numerical deflection and stress value. The findings show that the Reynolds numbers have a substantial effect to the FPCB’s deflection and stress. However, the BGA package’s positions on the FPCB were found to be insignificant to the responses. The actual BGA package on FPCB as presented in this paper will represent more realistic values of determined FPCB’s deflection and stress.
 ER  - 
 
@@ -2751,7 +2751,7 @@ PB  - Springer Netherlands
 SN  - 1572-882X
 DO  - 10.1007/s10570-015-0574-6
 M3  - 10.1007/s10570-015-0574-6
-UR  - http://dx.doi.org/10.1007/s10570-015-0574-6
+UR  - https://doi.org/10.1007/s10570-015-0574-6
 N2  - The desire of flexibility, light weight and low cost in current electronic device has increased the application of flexible printed circuit board (FPCB). This paper aims to investigate the effect of different Reynolds number (Re) toward FPCB attached with ball grid array (BGA) package in different arrangements. Actual BGA package with 100 solder joints incorporating FPCB was attached to a fixture in wind tunnel test section to perform FPCB’s deflection analysis with different flow velocities and package’s configurations. Furthermore, numerical simulation was also performed to obtain numerical deflection and stress value. The findings show that the Reynolds numbers have a substantial effect to the FPCB’s deflection and stress. However, the BGA package’s positions on the FPCB were found to be insignificant to the responses. The actual BGA package on FPCB as presented in this paper will represent more realistic values of determined FPCB’s deflection and stress.
 A1  - n, X i u x u a n   S u
 A1  - u, Q i n g l i n   W
@@ -2773,7 +2773,7 @@ PB  - Springer London
 SN  - 1433-2965
 DO  - 10.1007/s00198-016-3530-x
 M3  - 10.1007/s00198-016-3530-x
-UR  - http://dx.doi.org/10.1007/s00198-016-3530-x
+UR  - https://doi.org/10.1007/s00198-016-3530-x
 N2  - The desire of flexibility, light weight and low cost in current electronic device has increased the application of flexible printed circuit board (FPCB). This paper aims to investigate the effect of different Reynolds number (Re) toward FPCB attached with ball grid array (BGA) package in different arrangements. Actual BGA package with 100 solder joints incorporating FPCB was attached to a fixture in wind tunnel test section to perform FPCB’s deflection analysis with different flow velocities and package’s configurations. Furthermore, numerical simulation was also performed to obtain numerical deflection and stress value. The findings show that the Reynolds numbers have a substantial effect to the FPCB’s deflection and stress. However, the BGA package’s positions on the FPCB were found to be insignificant to the responses. The actual BGA package on FPCB as presented in this paper will represent more realistic values of determined FPCB’s deflection and stress.
 ER  - 
 
@@ -2791,7 +2791,7 @@ PB  - Springer-Verlag
 SN  - 1352-8661
 DO  - 10.1007/s10334-011-0268-5
 M3  - 10.1007/s10334-011-0268-5
-UR  - http://dx.doi.org/10.1007/s10334-011-0268-5
+UR  - https://doi.org/10.1007/s10334-011-0268-5
 N2  - The desire of flexibility, light weight and low cost in current electronic device has increased the application of flexible printed circuit board (FPCB). This paper aims to investigate the effect of different Reynolds number (Re) toward FPCB attached with ball grid array (BGA) package in different arrangements. Actual BGA package with 100 solder joints incorporating FPCB was attached to a fixture in wind tunnel test section to perform FPCB’s deflection analysis with different flow velocities and package’s configurations. Furthermore, numerical simulation was also performed to obtain numerical deflection and stress value. The findings show that the Reynolds numbers have a substantial effect to the FPCB’s deflection and stress. However, the BGA package’s positions on the FPCB were found to be insignificant to the responses. The actual BGA package on FPCB as presented in this paper will represent more realistic values of determined FPCB’s deflection and stress.
 ER  - 
 
@@ -2809,7 +2809,7 @@ PB  - Springer US
 SN  - 1544-1016
 DO  - 10.1007/s11666-018-0798-8
 M3  - 10.1007/s11666-018-0798-8
-UR  - http://dx.doi.org/10.1007/s11666-018-0798-8
+UR  - https://doi.org/10.1007/s11666-018-0798-8
 N2  - The patent literature concerning thermal spraying for biomedical applications is reviewed in this contribution. The patents were compiled from multiple databases search spanning the 2005-2018 period. For clarity and ease of reading, the results have been grouped into sections according to four individual material groups (apatites, titanium, oxide ceramics, other), with the secondary sorting criterion being related to the specific bioapplication areas (maxillofacial, orthopedic, methods). Lastly, the patents are grouped according to the selected thermal spray method within the individual subsections. In the paper, recent R&D trends in this field are further identified and briefly commented.
 A1  - k, J .   C i z e
 A1  - k, J .   M a t e j i c e
@@ -2829,7 +2829,7 @@ PB  - Springer US
 SN  - 1879-1123
 DO  - 10.1007/s13361-018-1971-5
 M3  - 10.1007/s13361-018-1971-5
-UR  - http://dx.doi.org/10.1007/s13361-018-1971-5
+UR  - https://doi.org/10.1007/s13361-018-1971-5
 N2  - The patent literature concerning thermal spraying for biomedical applications is reviewed in this contribution. The patents were compiled from multiple databases search spanning the 2005-2018 period. For clarity and ease of reading, the results have been grouped into sections according to four individual material groups (apatites, titanium, oxide ceramics, other), with the secondary sorting criterion being related to the specific bioapplication areas (maxillofacial, orthopedic, methods). Lastly, the patents are grouped according to the selected thermal spray method within the individual subsections. In the paper, recent R&D trends in this field are further identified and briefly commented.
 ER  - 
 
@@ -2847,7 +2847,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-017-1602-7
 M3  - 10.1007/s12274-017-1602-7
-UR  - http://dx.doi.org/10.1007/s12274-017-1602-7
+UR  - https://doi.org/10.1007/s12274-017-1602-7
 N2  - The patent literature concerning thermal spraying for biomedical applications is reviewed in this contribution. The patents were compiled from multiple databases search spanning the 2005-2018 period. For clarity and ease of reading, the results have been grouped into sections according to four individual material groups (apatites, titanium, oxide ceramics, other), with the secondary sorting criterion being related to the specific bioapplication areas (maxillofacial, orthopedic, methods). Lastly, the patents are grouped according to the selected thermal spray method within the individual subsections. In the paper, recent R&D trends in this field are further identified and briefly commented.
 A1  - o, K a r i n a   B .   H u e s
 A1  - s, V e r ó n i c a   P a l o m a r e
@@ -2869,7 +2869,7 @@ PB  - Science China Press
 SN  - 2199-4501
 DO  - 10.1007/s40843-016-0128-8
 M3  - 10.1007/s40843-016-0128-8
-UR  - http://dx.doi.org/10.1007/s40843-016-0128-8
+UR  - https://doi.org/10.1007/s40843-016-0128-8
 N2  - The patent literature concerning thermal spraying for biomedical applications is reviewed in this contribution. The patents were compiled from multiple databases search spanning the 2005-2018 period. For clarity and ease of reading, the results have been grouped into sections according to four individual material groups (apatites, titanium, oxide ceramics, other), with the secondary sorting criterion being related to the specific bioapplication areas (maxillofacial, orthopedic, methods). Lastly, the patents are grouped according to the selected thermal spray method within the individual subsections. In the paper, recent R&D trends in this field are further identified and briefly commented.
 A1  - n, S h u a i   C h e
 A1  - u, Z h e n g   L o
@@ -2893,7 +2893,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-018-2237-z
 M3  - 10.1007/s12274-018-2237-z
-UR  - http://dx.doi.org/10.1007/s12274-018-2237-z
+UR  - https://doi.org/10.1007/s12274-018-2237-z
 N2  - The patent literature concerning thermal spraying for biomedical applications is reviewed in this contribution. The patents were compiled from multiple databases search spanning the 2005-2018 period. For clarity and ease of reading, the results have been grouped into sections according to four individual material groups (apatites, titanium, oxide ceramics, other), with the secondary sorting criterion being related to the specific bioapplication areas (maxillofacial, orthopedic, methods). Lastly, the patents are grouped according to the selected thermal spray method within the individual subsections. In the paper, recent R&D trends in this field are further identified and briefly commented.
 A1  - e, N a t t i n e e   B u m b u d s a n p h a r o k
 A1  - o, S e o n g h y u k   K
@@ -2913,7 +2913,7 @@ PB  - Springer-Verlag
 SN  - 0174-1551
 DO  - 10.1007/s00270-010-9954-3
 M3  - 10.1007/s00270-010-9954-3
-UR  - http://dx.doi.org/10.1007/s00270-010-9954-3
+UR  - https://doi.org/10.1007/s00270-010-9954-3
 N2  - The patent literature concerning thermal spraying for biomedical applications is reviewed in this contribution. The patents were compiled from multiple databases search spanning the 2005-2018 period. For clarity and ease of reading, the results have been grouped into sections according to four individual material groups (apatites, titanium, oxide ceramics, other), with the secondary sorting criterion being related to the specific bioapplication areas (maxillofacial, orthopedic, methods). Lastly, the patents are grouped according to the selected thermal spray method within the individual subsections. In the paper, recent R&D trends in this field are further identified and briefly commented.
 ER  - 
 
@@ -2931,7 +2931,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1613-4990
 DO  - 10.1007/s10404-018-2059-z
 M3  - 10.1007/s10404-018-2059-z
-UR  - http://dx.doi.org/10.1007/s10404-018-2059-z
+UR  - https://doi.org/10.1007/s10404-018-2059-z
 N2  - In this paper, an anemometric sticker sensor is presented, which can be used as a flag to verify the completion of a particular step inside microfluidic devices, the presence of leakages or trapped air bubbles. The similarity of the fabrication method to the printing and roll-to-roll techniques offers a simple and realistic mass-producible solution for direct monitoring of microfluidic protocols inside lab-on-a-chip devices. The detector has been fabricated on a sticker, which presents low space needs and can be easily applied on the test chip with no strict alignment requirements. The introduced idea fulfills the sensing demand that currently microfluidic devices present, being reusable or disposable due to its low cost requirements.
 A1  - i, J .   E t x e b a r r i a - E l e z g a r a
 A1  - o, J .   B e r g a n z
@@ -2952,7 +2952,7 @@ PB  - Springer-Verlag
 SN  - 1432-1459
 DO  - 10.1007/s00415-010-5575-7
 M3  - 10.1007/s00415-010-5575-7
-UR  - http://dx.doi.org/10.1007/s00415-010-5575-7
+UR  - https://doi.org/10.1007/s00415-010-5575-7
 N2  - In this paper, an anemometric sticker sensor is presented, which can be used as a flag to verify the completion of a particular step inside microfluidic devices, the presence of leakages or trapped air bubbles. The similarity of the fabrication method to the printing and roll-to-roll techniques offers a simple and realistic mass-producible solution for direct monitoring of microfluidic protocols inside lab-on-a-chip devices. The detector has been fabricated on a sticker, which presents low space needs and can be easily applied on the test chip with no strict alignment requirements. The introduced idea fulfills the sensing demand that currently microfluidic devices present, being reusable or disposable due to its low cost requirements.
 ER  - 
 
@@ -2970,7 +2970,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1432-1998
 DO  - 10.1007/s00247-014-2968-2
 M3  - 10.1007/s00247-014-2968-2
-UR  - http://dx.doi.org/10.1007/s00247-014-2968-2
+UR  - https://doi.org/10.1007/s00247-014-2968-2
 N2  - In this paper, an anemometric sticker sensor is presented, which can be used as a flag to verify the completion of a particular step inside microfluidic devices, the presence of leakages or trapped air bubbles. The similarity of the fabrication method to the printing and roll-to-roll techniques offers a simple and realistic mass-producible solution for direct monitoring of microfluidic protocols inside lab-on-a-chip devices. The detector has been fabricated on a sticker, which presents low space needs and can be easily applied on the test chip with no strict alignment requirements. The introduced idea fulfills the sensing demand that currently microfluidic devices present, being reusable or disposable due to its low cost requirements.
 ER  - 
 
@@ -2988,7 +2988,7 @@ PB  - Springer US
 SN  - 1559-1166
 DO  - 10.1007/s12031-012-9923-1
 M3  - 10.1007/s12031-012-9923-1
-UR  - http://dx.doi.org/10.1007/s12031-012-9923-1
+UR  - https://doi.org/10.1007/s12031-012-9923-1
 N2  - In this paper, an anemometric sticker sensor is presented, which can be used as a flag to verify the completion of a particular step inside microfluidic devices, the presence of leakages or trapped air bubbles. The similarity of the fabrication method to the printing and roll-to-roll techniques offers a simple and realistic mass-producible solution for direct monitoring of microfluidic protocols inside lab-on-a-chip devices. The detector has been fabricated on a sticker, which presents low space needs and can be easily applied on the test chip with no strict alignment requirements. The introduced idea fulfills the sensing demand that currently microfluidic devices present, being reusable or disposable due to its low cost requirements.
 ER  - 
 
@@ -3006,7 +3006,7 @@ PB  - Springer-Verlag
 SN  - 1879-1123
 DO  - 10.1007/s13361-013-0649-2
 M3  - 10.1007/s13361-013-0649-2
-UR  - http://dx.doi.org/10.1007/s13361-013-0649-2
+UR  - https://doi.org/10.1007/s13361-013-0649-2
 N2  - In this paper, an anemometric sticker sensor is presented, which can be used as a flag to verify the completion of a particular step inside microfluidic devices, the presence of leakages or trapped air bubbles. The similarity of the fabrication method to the printing and roll-to-roll techniques offers a simple and realistic mass-producible solution for direct monitoring of microfluidic protocols inside lab-on-a-chip devices. The detector has been fabricated on a sticker, which presents low space needs and can be easily applied on the test chip with no strict alignment requirements. The introduced idea fulfills the sensing demand that currently microfluidic devices present, being reusable or disposable due to its low cost requirements.
 A1  - g, J u d i t h   S j o b e r
 ER  - 
@@ -3025,7 +3025,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1352-8661
 DO  - 10.1007/s10334-015-0488-1
 M3  - 10.1007/s10334-015-0488-1
-UR  - http://dx.doi.org/10.1007/s10334-015-0488-1
+UR  - https://doi.org/10.1007/s10334-015-0488-1
 N2  - In this paper, an anemometric sticker sensor is presented, which can be used as a flag to verify the completion of a particular step inside microfluidic devices, the presence of leakages or trapped air bubbles. The similarity of the fabrication method to the printing and roll-to-roll techniques offers a simple and realistic mass-producible solution for direct monitoring of microfluidic protocols inside lab-on-a-chip devices. The detector has been fabricated on a sticker, which presents low space needs and can be easily applied on the test chip with no strict alignment requirements. The introduced idea fulfills the sensing demand that currently microfluidic devices present, being reusable or disposable due to its low cost requirements.
 ER  - 
 
@@ -3043,7 +3043,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1869-4101
 DO  - 10.1007/s13244-011-0077-4
 M3  - 10.1007/s13244-011-0077-4
-UR  - http://dx.doi.org/10.1007/s13244-011-0077-4
+UR  - https://doi.org/10.1007/s13244-011-0077-4
 N2  - In this paper, an anemometric sticker sensor is presented, which can be used as a flag to verify the completion of a particular step inside microfluidic devices, the presence of leakages or trapped air bubbles. The similarity of the fabrication method to the printing and roll-to-roll techniques offers a simple and realistic mass-producible solution for direct monitoring of microfluidic protocols inside lab-on-a-chip devices. The detector has been fabricated on a sticker, which presents low space needs and can be easily applied on the test chip with no strict alignment requirements. The introduced idea fulfills the sensing demand that currently microfluidic devices present, being reusable or disposable due to its low cost requirements.
 ER  - 
 
@@ -3061,7 +3061,7 @@ PB  - Springer Netherlands
 SN  - 1877-8755
 DO  - 10.1007/s13105-016-0508-2
 M3  - 10.1007/s13105-016-0508-2
-UR  - http://dx.doi.org/10.1007/s13105-016-0508-2
+UR  - https://doi.org/10.1007/s13105-016-0508-2
 N2  -  Dear colleagues, 
 ER  - 
 
@@ -3079,7 +3079,7 @@ PB  - Springer International Publishing
 SN  - 2197-425X
 DO  - 10.1186/s40635-017-0151-4
 M3  - 10.1186/s40635-017-0151-4
-UR  - http://dx.doi.org/10.1186/s40635-017-0151-4
+UR  - https://doi.org/10.1186/s40635-017-0151-4
 N2  -  Dear colleagues, 
 ER  - 
 
@@ -3097,7 +3097,7 @@ PB  - Springer International Publishing
 SN  - 2363-9520
 DO  - 10.1007/s40964-016-0008-5
 M3  - 10.1007/s40964-016-0008-5
-UR  - http://dx.doi.org/10.1007/s40964-016-0008-5
+UR  - https://doi.org/10.1007/s40964-016-0008-5
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - t, J a v a i d   B u t
 A1  - u, H a b t o m   M e b r a h t
@@ -3118,7 +3118,7 @@ PB  - Springer Singapore
 SN  - 2543-2141
 DO  - 10.1016/S1672-6529(16)60429-8
 M3  - 10.1016/S1672-6529(16)60429-8
-UR  - http://dx.doi.org/10.1016/S1672-6529(16)60429-8
+UR  - https://doi.org/10.1016/S1672-6529(16)60429-8
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - i, J u n   C a
 A1  - i, Y i n g y i n g   S h
@@ -3140,7 +3140,7 @@ PB  - Springer US
 SN  - 1879-1123
 DO  - 10.1007/s13361-014-0918-8
 M3  - 10.1007/s13361-014-0918-8
-UR  - http://dx.doi.org/10.1007/s13361-014-0918-8
+UR  - https://doi.org/10.1007/s13361-014-0918-8
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - g, J u d i t h   S j o b e r
 ER  - 
@@ -3159,7 +3159,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2005-4602
 DO  - 10.1007/s12541-016-0066-0
 M3  - 10.1007/s12541-016-0066-0
-UR  - http://dx.doi.org/10.1007/s12541-016-0066-0
+UR  - https://doi.org/10.1007/s12541-016-0066-0
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - e, H y u n s e o p   L e
 A1  - e, D a s o l   L e
@@ -3180,7 +3180,7 @@ PB  - Springer US
 SN  - 1879-1123
 DO  - 10.1007/s13361-016-1413-1
 M3  - 10.1007/s13361-016-1413-1
-UR  - http://dx.doi.org/10.1007/s13361-016-1413-1
+UR  - https://doi.org/10.1007/s13361-016-1413-1
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - g, J u d i t h   S j o b e r
 ER  - 
@@ -3199,7 +3199,7 @@ PB  - Springer-Verlag
 SN  - 1432-1238
 DO  - 10.1007/s00134-012-2683-0
 M3  - 10.1007/s00134-012-2683-0
-UR  - http://dx.doi.org/10.1007/s00134-012-2683-0
+UR  - https://doi.org/10.1007/s00134-012-2683-0
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3217,7 +3217,7 @@ PB  - Springer-Verlag
 SN  - 1433-2965
 DO  - 10.1007/s00198-013-2312-y
 M3  - 10.1007/s00198-013-2312-y
-UR  - http://dx.doi.org/10.1007/s00198-013-2312-y
+UR  - https://doi.org/10.1007/s00198-013-2312-y
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3235,7 +3235,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1433-7339
 DO  - 10.1007/s00520-016-3209-z
 M3  - 10.1007/s00520-016-3209-z
-UR  - http://dx.doi.org/10.1007/s00520-016-3209-z
+UR  - https://doi.org/10.1007/s00520-016-3209-z
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3253,7 +3253,7 @@ PB  - Springer-Verlag
 SN  - 1879-1123
 DO  - 10.1007/s13361-011-0127-7
 M3  - 10.1007/s13361-011-0127-7
-UR  - http://dx.doi.org/10.1007/s13361-011-0127-7
+UR  - https://doi.org/10.1007/s13361-011-0127-7
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3271,7 +3271,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-014-0622-9
 M3  - 10.1007/s12274-014-0622-9
-UR  - http://dx.doi.org/10.1007/s12274-014-0622-9
+UR  - https://doi.org/10.1007/s12274-014-0622-9
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - r, S u n i l   P .   L o n k a
 A1  - h, Y o g e s h   S .   D e s h m u k
@@ -3292,7 +3292,7 @@ PB  - Springer Netherlands
 SN  - 1572-896X
 DO  - 10.1007/s11051-014-2561-5
 M3  - 10.1007/s11051-014-2561-5
-UR  - http://dx.doi.org/10.1007/s11051-014-2561-5
+UR  - https://doi.org/10.1007/s11051-014-2561-5
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - o, S h a o j u a n   L u
 A1  - g, D o n g n i n g   Y a n
@@ -3314,7 +3314,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-018-1997-9
 M3  - 10.1007/s12274-018-1997-9
-UR  - http://dx.doi.org/10.1007/s12274-018-1997-9
+UR  - https://doi.org/10.1007/s12274-018-1997-9
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - a, M i n g y u a n   M
 A1  - g, Z h u o   K a n
@@ -3340,7 +3340,7 @@ PB  - Science China Press
 SN  - 1869-1870
 DO  - 10.1007/s11426-015-5328-7
 M3  - 10.1007/s11426-015-5328-7
-UR  - http://dx.doi.org/10.1007/s11426-015-5328-7
+UR  - https://doi.org/10.1007/s11426-015-5328-7
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - u, P i n g   F
 A1  - g, D o n g   Y a n
@@ -3364,7 +3364,7 @@ PB  - Springer-Verlag
 SN  - 1352-8661
 DO  - 10.1007/s10334-012-0324-9
 M3  - 10.1007/s10334-012-0324-9
-UR  - http://dx.doi.org/10.1007/s10334-012-0324-9
+UR  - https://doi.org/10.1007/s10334-012-0324-9
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3382,7 +3382,7 @@ PB  - Springer Milan
 SN  - 1970-9366
 DO  - 10.1007/s11739-012-0888-4
 M3  - 10.1007/s11739-012-0888-4
-UR  - http://dx.doi.org/10.1007/s11739-012-0888-4
+UR  - https://doi.org/10.1007/s11739-012-0888-4
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3400,7 +3400,7 @@ PB  - BioMed Central
 SN  - 1364-8535
 DO  - 10.1186/cc8498
 M3  - 10.1186/cc8498
-UR  - http://dx.doi.org/10.1186/cc8498
+UR  - https://doi.org/10.1186/cc8498
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3418,7 +3418,7 @@ PB  - BioMed Central
 SN  - 1364-8535
 DO  - 10.1186/cc8795
 M3  - 10.1186/cc8795
-UR  - http://dx.doi.org/10.1186/cc8795
+UR  - https://doi.org/10.1186/cc8795
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3436,7 +3436,7 @@ PB  - BioMed Central
 SN  - 1364-8535
 DO  - 10.1186/cc8525
 M3  - 10.1186/cc8525
-UR  - http://dx.doi.org/10.1186/cc8525
+UR  - https://doi.org/10.1186/cc8525
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3454,7 +3454,7 @@ PB  - BioMed Central
 SN  - 1364-8535
 DO  - 10.1186/cc8531
 M3  - 10.1186/cc8531
-UR  - http://dx.doi.org/10.1186/cc8531
+UR  - https://doi.org/10.1186/cc8531
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3472,7 +3472,7 @@ PB  - BioMed Central
 SN  - 1364-8535
 DO  - 10.1186/cc8796
 M3  - 10.1186/cc8796
-UR  - http://dx.doi.org/10.1186/cc8796
+UR  - https://doi.org/10.1186/cc8796
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3490,7 +3490,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1352-8661
 DO  - 10.1007/s10334-013-0385-4
 M3  - 10.1007/s10334-013-0385-4
-UR  - http://dx.doi.org/10.1007/s10334-013-0385-4
+UR  - https://doi.org/10.1007/s10334-013-0385-4
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3508,7 +3508,7 @@ PB  - Springer Milan
 SN  - 2281-7565
 DO  - 10.1007/s40336-015-0114-2
 M3  - 10.1007/s40336-015-0114-2
-UR  - http://dx.doi.org/10.1007/s40336-015-0114-2
+UR  - https://doi.org/10.1007/s40336-015-0114-2
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3526,7 +3526,7 @@ PB  - Korean Society for Precision Engineering
 SN  - 2005-4602
 DO  - 10.1007/s12541-016-0119-4
 M3  - 10.1007/s12541-016-0119-4
-UR  - http://dx.doi.org/10.1007/s12541-016-0119-4
+UR  - https://doi.org/10.1007/s12541-016-0119-4
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - e, C h o o n - M a n   L e
 A1  - o, W a n - S i k   W o
@@ -3548,7 +3548,7 @@ PB  - Springer Singapore
 SN  - 1860-2134
 DO  - 10.1016/S0894-9166(11)60007-4
 M3  - 10.1016/S0894-9166(11)60007-4
-UR  - http://dx.doi.org/10.1016/S0894-9166(11)60007-4
+UR  - https://doi.org/10.1016/S0894-9166(11)60007-4
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - n, C .   Q .   C h e
 A1  - i, J .   Z .   C u
@@ -3585,7 +3585,7 @@ PB  - Springer-Verlag
 SN  - 1433-2965
 DO  - 10.1007/s00198-010-1247-9
 M3  - 10.1007/s00198-010-1247-9
-UR  - http://dx.doi.org/10.1007/s00198-010-1247-9
+UR  - https://doi.org/10.1007/s00198-010-1247-9
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 A1  - r, T h e   E d i t o
 ER  - 
@@ -3604,7 +3604,7 @@ PB  - Springer Berlin Heidelberg
 SN  - 1877-6566
 DO  - 10.1007/s11568-010-9143-0
 M3  - 10.1007/s11568-010-9143-0
-UR  - http://dx.doi.org/10.1007/s11568-010-9143-0
+UR  - https://doi.org/10.1007/s11568-010-9143-0
 N2  - A number of different parts for mechanical testing were produced using composite metal foil manufacturing (CMFM). This process is a combination of laminated object manufacturing and brazing technology. Aluminium is one of the toughest metals to join and CMFM can achieve this task with ease. By using aluminium 1050 foils of 0.1 mm thickness, various parts were made according to British and International Standards, including lap joints, peel specimens, dog-bone specimens and tested for their mechanical properties. A special, 80 % zinc and 20 % aluminium by weight, brazing paste was utilized for joining the foils together. The test of the single lap joints show that none of the specimens failed at the bonded area and the failure was always due to fracture of the parent metal. Cohesive failure was also observed for the single lap joints by using 10 mm thick aluminium metal plates. It helped in calculating the lap shear strength which is a useful design parameter. The peel test showed good bond consistency in all the specimens with an average peel strength of 20 MPa. Comparative tensile test was conducted with a dog-bone specimen machined from a solid block of aluminium 1050 and specimens made with CMFM. The results showed that the specimens made by CMFM fracture at force values that are higher than that of the parent metal. This demonstrates that CMFM has the capability to produce high quality and stronger parts as compared to conventional machining methods employed for the production of metal parts. The effect of using different number of layers for the same cross-sectional area has also been investigated.
 ER  - 
 
@@ -3622,7 +3622,7 @@ PB  - Springer Netherlands
 SN  - 1572-9672
 DO  - 10.1007/s11214-017-0439-4
 M3  - 10.1007/s11214-017-0439-4
-UR  - http://dx.doi.org/10.1007/s11214-017-0439-4
+UR  - https://doi.org/10.1007/s11214-017-0439-4
 N2  - OSIRIS-REx will return pristine samples of carbonaceous asteroid Bennu. This article describes how pristine was defined based on expectations of Bennu and on a realistic understanding of what is achievable with a constrained schedule and budget, and how that definition flowed to requirements and implementation. To return a pristine sample, the OSIRIS-REx spacecraft sampling hardware was maintained at level 100 A/2 and <180 ng/cm2 of amino acids and hydrazine on the sampler head through precision cleaning, control of materials, and vigilance. Contamination is further characterized via witness material exposed to the spacecraft assembly and testing environment as well as in space. This characterization provided knowledge of the expected background and will be used in conjunction with archived spacecraft components for comparison with the samples when they are delivered to Earth for analysis. Most of all, the cleanliness of the OSIRIS-REx spacecraft was achieved through communication among scientists, engineers, managers, and technicians.
 A1  - n, J .   P .   D w o r k i
 A1  - n, L .   A .   A d e l m a
@@ -3702,7 +3702,7 @@ PB  - Springer-Verlag
 SN  - 1352-8661
 DO  - 10.1007/s10334-011-0266-7
 M3  - 10.1007/s10334-011-0266-7
-UR  - http://dx.doi.org/10.1007/s10334-011-0266-7
+UR  - https://doi.org/10.1007/s10334-011-0266-7
 N2  - OSIRIS-REx will return pristine samples of carbonaceous asteroid Bennu. This article describes how pristine was defined based on expectations of Bennu and on a realistic understanding of what is achievable with a constrained schedule and budget, and how that definition flowed to requirements and implementation. To return a pristine sample, the OSIRIS-REx spacecraft sampling hardware was maintained at level 100 A/2 and <180 ng/cm2 of amino acids and hydrazine on the sampler head through precision cleaning, control of materials, and vigilance. Contamination is further characterized via witness material exposed to the spacecraft assembly and testing environment as well as in space. This characterization provided knowledge of the expected background and will be used in conjunction with archived spacecraft components for comparison with the samples when they are delivered to Earth for analysis. Most of all, the cleanliness of the OSIRIS-REx spacecraft was achieved through communication among scientists, engineers, managers, and technicians.
 ER  - 
 
@@ -3720,7 +3720,7 @@ PB  - Pleiades Publishing
 SN  - 1608-3393
 DO  - 10.1134/S1070428017090019
 M3  - 10.1134/S1070428017090019
-UR  - http://dx.doi.org/10.1134/S1070428017090019
+UR  - https://doi.org/10.1134/S1070428017090019
 N2  - OSIRIS-REx will return pristine samples of carbonaceous asteroid Bennu. This article describes how pristine was defined based on expectations of Bennu and on a realistic understanding of what is achievable with a constrained schedule and budget, and how that definition flowed to requirements and implementation. To return a pristine sample, the OSIRIS-REx spacecraft sampling hardware was maintained at level 100 A/2 and <180 ng/cm2 of amino acids and hydrazine on the sampler head through precision cleaning, control of materials, and vigilance. Contamination is further characterized via witness material exposed to the spacecraft assembly and testing environment as well as in space. This characterization provided knowledge of the expected background and will be used in conjunction with archived spacecraft components for comparison with the samples when they are delivered to Earth for analysis. Most of all, the cleanliness of the OSIRIS-REx spacecraft was achieved through communication among scientists, engineers, managers, and technicians.
 A1  - n, I .   S .   A n t i p i
 A1  - a, M .   A .   K a z y m o v
@@ -3796,7 +3796,7 @@ PB  - Tsinghua University Press
 SN  - 1998-0000
 DO  - 10.1007/s12274-018-2048-2
 M3  - 10.1007/s12274-018-2048-2
-UR  - http://dx.doi.org/10.1007/s12274-018-2048-2
+UR  - https://doi.org/10.1007/s12274-018-2048-2
 N2  - OSIRIS-REx will return pristine samples of carbonaceous asteroid Bennu. This article describes how pristine was defined based on expectations of Bennu and on a realistic understanding of what is achievable with a constrained schedule and budget, and how that definition flowed to requirements and implementation. To return a pristine sample, the OSIRIS-REx spacecraft sampling hardware was maintained at level 100 A/2 and <180 ng/cm2 of amino acids and hydrazine on the sampler head through precision cleaning, control of materials, and vigilance. Contamination is further characterized via witness material exposed to the spacecraft assembly and testing environment as well as in space. This characterization provided knowledge of the expected background and will be used in conjunction with archived spacecraft components for comparison with the samples when they are delivered to Earth for analysis. Most of all, the cleanliness of the OSIRIS-REx spacecraft was achieved through communication among scientists, engineers, managers, and technicians.
 A1  - g, Y u p i n g   W a n
 A1  - g, D i   W a n
@@ -3818,7 +3818,7 @@ PB  - Springer Netherlands
 SN  - 1572-8935
 DO  - 10.1007/s10965-017-1227-2
 M3  - 10.1007/s10965-017-1227-2
-UR  - http://dx.doi.org/10.1007/s10965-017-1227-2
+UR  - https://doi.org/10.1007/s10965-017-1227-2
 N2  - Biodegradable polymers are identified as substantial materials for biomedical applications. These polymers have the ability to deteriorate through an unpretentious hydrolysis and eliminated through kidneys’ functions or metabolic processes. Among widely used biodegradable polymers in biomedical applications, poly(lactic acid) (PLA) is becoming one of the most paramount polymers. Synthesizing PLA through melt/solution polycondensation polymerizations makes it relatively easy to tailor properties of final product. However, their synthesis reactions are affected by several parameters such as polymerization time, temperature, pressure, catalysts, and the polarity of the solvent. Moreover, equilibrium reactions are controlled through utilizing a hydrophilic monomer such as ethylene glycol (EG). These factors can strongly impact final properties of PLA. Thus, it is indispensable to comprehend the effect of operating parameters during the polymerization process. Optimizing synthesis conditions can be accomplished through reducing side reactions. Furthermore, this can be achieved through racemization by utilizing chain extenders to build high molecular weight and enhance thermal stability. In this review, the design and fabrication of porous PLA scaffolds and their physicomechanical behavior are reviewed. Different PLA scaffold parameters were investigated thoroughly, which include biocompatibility, biodegradability, and mechanical properties for different porosity and pore sizes to mimic the complex architecture of the natural tissue regeneration.
 A1  - a, M u s t a f a   A b u   G h a l i
 A1  - n, Y a s e r   D a h m a

--- a/download-citation/2018-12-13.ris
+++ b/download-citation/2018-12-13.ris
@@ -11,7 +11,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C7TC04804A
 M3  - 10.1039/C7TC04804A
-UR  - http://dx.doi.org/10.1039/C7TC04804A
+UR  - https://doi.org/10.1039/C7TC04804A
 N2  - Inorganic printed electronics is now recognized as an area of tremendous commercial, potential and technical progress. Many research groups are actively involved worldwide in developing metal nanoparticle inks and precursors for printing inorganic/organic materials using different printing techniques. This review article focuses on inkjet printed metal structures and their applications. It comprises ink formulation, optimal droplet formation as well as adhesion of the printed patterns at the underlying substrate and post-treatment like sintering to be considered in the initial ink design. Besides some examples demonstrating aspects on ink formulation via patterning solid surfaces such as glass and silicon oxide, special emphasis will be placed on compatibility for usage in plastic and paper electronics. Printing of nanoparticles of copper, silver, gold etc. will be discussed and will be compared to printing of a variety of metal–organic precursor inks. Finally, a brief account on exemplary applications using the printed inorganic nanoparticles/materials is provided.
 A1  - Raut, N. C.
 A1  - Al-Shamery, K.
@@ -31,7 +31,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C7CS00192D
 M3  - 10.1039/C7CS00192D
-UR  - http://dx.doi.org/10.1039/C7CS00192D
+UR  - https://doi.org/10.1039/C7CS00192D
 N2  - Flexible and wearable electronics is one major technology after smartphones. It shows remarkable application potential in displays and informatics, robotics, sports, energy harvesting and storage, and medicine. As an indispensable part and the cornerstone of these devices, soft metal electrodes (SMEs) are of great significance. Compared with conventional physical processes such as vacuum thermal deposition and sputtering, chemical approaches for preparing SMEs show significant advantages in terms of scalability, low-cost, and compatibility with the soft materials and substrates used for the devices. This review article provides a detailed overview on how to chemically fabricate SMEs, including the material preparation, fabrication technologies, methods to characterize their key properties, and representative studies on different wearable applications.
 A1  - Wang, Dongrui
 A1  - Zhang, Yaokang
@@ -55,7 +55,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C7TC00038C
 M3  - 10.1039/C7TC00038C
-UR  - http://dx.doi.org/10.1039/C7TC00038C
+UR  - https://doi.org/10.1039/C7TC00038C
 N2  - In recent years, wearable electronics have experienced tremendous development due to their promising applications in fields such as portable, flexible/stretchable human-interactive sensors, displays, and energy devices. To effectively fabricate wearable electronics, a high-efficient, cost-saving, and eco-friendly manufacture technology is required. Inkjet printing, which rapidly, precisely, and reproducibly deposits a broad variety of functional materials in a non-impact, addictive patterning, and maskless approach, serves as an effective tool for the fabrication of wearable electronics. In this review, the recent advances in inks, strategies, and the applications of inkjet-printed wearable electronics are summarized. Based on uniform and high-resolution patterns, well-compatible functional inks can be deposited to fabricate flexible/stretchable and durable wearable electronics. Perspectives on the remaining challenges and future developments are also proposed.
 A1  - Gao, Meng
 A1  - Li, Lihong
@@ -76,7 +76,7 @@ PB  - The Royal Society of Chemistry
 SN  - current
 DO  - 10.1039/C7RA07191D
 M3  - 10.1039/C7RA07191D
-UR  - http://dx.doi.org/10.1039/C7RA07191D
+UR  - https://doi.org/10.1039/C7RA07191D
 N2  - The Internet of Things (IoT) has limitless possibilities for applications in the entire spectrum of our daily lives, from healthcare to automobiles to public safety. The IoT is expected to grow into a trillion dollar industry worldwide over the next decade. The components of the IoT will be integrated with cloud computing, which will facilitate easy access and analysis of big data stored in cloud systems across the globe. Radio frequency identification (RFID) technology is based on wireless communication systems and offers easy integration into the Internet cloud system. The potential of RFID tag sensor technologies has been studied in different industrial sectors including healthcare, food safety, environmental pollution, anti-counterfeiting of bank-notes and fake medicines, factories, customer shopping behavior, logistics, public transport, and safety. In this review article, the role of inkjet-printed RFID tag sensors is described in the emerging fields of IoT and the Internet of Nano Things (IoNT). This review is concerned with the use of inkjet-printed nanomaterials to fabricate RFID-enabled devices as a component of IoT technology. Inkjet-printed flexible RFID tag sensors based on nanomaterials including multilayer graphene, carbon nanotubes, gold, silver and copper nanoparticles, conductive polymers and their based composites used for detecting toxic gases and chemicals are discussed. Inkjet-printed nanomaterial-based RFID tag sensors that can be easily printed on flexible paper, plastic, textile, glass, and metallic surfaces, show potential in flexible and wearable electronics technologies. Finally, challenges such as energy and safety issues for RFID tag sensors are analyzed.
 A1  - Singh, Ravina
 A1  - Singh, Eric
@@ -97,7 +97,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C7NR01604B
 M3  - 10.1039/C7NR01604B
-UR  - http://dx.doi.org/10.1039/C7NR01604B
+UR  - https://doi.org/10.1039/C7NR01604B
 N2  - Owing to their capability of bypassing conventional high-priced and inflexible silicon based electronics to manufacture a variety of devices on flexible substrates by using large-scale and high-volume printing techniques, printed electronics (PE) have attracted increasing attention in the field of manufacturing industry for electronic devices. This simple and cost-effective approach could enhance current methods of constructing a patterned surface for nanomaterials and offer opportunities for developing fully-printed functional devices, especially offering the possibility of ubiquitous low-cost and flexible devices. This review presents a summary of work to date on the inorganic nanomaterials involved in PE applications, focused on the utilization of inorganic nanomaterials-based inks in the successful preparation of printed conductive patterns, electrodes, sensors, thin film transistors (TFTs) and other micro-/nanoscale devices. The printing techniques, sintering methods and printability of functional inks with their associated challenges are discussed, and we look forward so you can glimpse the future of PE applications.
 A1  - Wu, Wei
 ER  - 
@@ -116,7 +116,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C4TC02418D
 M3  - 10.1039/C4TC02418D
-UR  - http://dx.doi.org/10.1039/C4TC02418D
+UR  - https://doi.org/10.1039/C4TC02418D
 N2  - Soft lithographic methods describe a set of printing methods which are widely used for the preparation of structured surfaces. Structured surfaces are essential components in the field of (opto-)electronic devices such as organic light emitting diodes, photovoltaics or organic field effect transistors. In recent years, crucial progress has been achieved in the development of patterned metal coatings for these applications. This review focusses on new strategies for soft lithographical printing of metal structures emphasizing the subtle interplay of printing techniques, metal precursor chemistry, and surface functionalization strategies.
 A1  - Wisser, F. M.
 A1  - Schumm, B.
@@ -139,7 +139,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C4NR01600A
 M3  - 10.1039/C4NR01600A
-UR  - http://dx.doi.org/10.1039/C4NR01600A
+UR  - https://doi.org/10.1039/C4NR01600A
 N2  - We present the science and technology roadmap for graphene, related two-dimensional crystals, and hybrid systems, targeting an evolution in technology, that might lead to impacts and benefits reaching into most areas of society. This roadmap was developed within the framework of the European Graphene Flagship and outlines the main targets and research areas as best understood at the start of this ambitious project. We provide an overview of the key aspects of graphene and related materials (GRMs), ranging from fundamental research challenges to a variety of applications in a large number of sectors, highlighting the steps necessary to take GRMs from a state of raw potential to a point where they might revolutionize multiple industries. We also define an extensive list of acronyms in an effort to standardize the nomenclature in this emerging field.
 A1  - Ferrari, Andrea C.
 A1  - Bonaccorso, Francesco
@@ -221,7 +221,7 @@ PB  - The Royal Society of Chemistry
 SN  - current
 DO  - 10.1039/C5RA16478H
 M3  - 10.1039/C5RA16478H
-UR  - http://dx.doi.org/10.1039/C5RA16478H
+UR  - https://doi.org/10.1039/C5RA16478H
 N2  - Smart wearable devices can be fabricated using flexible and linear cable-type materials for applications in energy, electronics, sensing and healthcare products. Such wearable devices have been prepared by incorporating conductive nanostructures, metallic nanomaterials, hybrid nanocomposites and polymer nanocomposites on the surface of flexible and permeable cotton materials (threads, fibers, yarns and fabrics). In this paper, we present an overview of preparation methods of various conductive nanomaterials, hybrids and polymer nanocomposites and their embedment on cotton based flexible materials. The embedment of these functional hybrid nanostructures on the porous and permeable materials has provided the necessary potential for the development of wearable smart devices with improved characteristic properties. Moreover, the diversity of these characteristic properties and potential applications of functionalized cotton materials has been also discussed. This review paper will boost encouragement for the development of next generation smart and flexible devices which could be worn by human beings.
 A1  - Hansora, D. P.
 A1  - Shimpi, N. G.
@@ -242,7 +242,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C6NR08220C
 M3  - 10.1039/C6NR08220C
-UR  - http://dx.doi.org/10.1039/C6NR08220C
+UR  - https://doi.org/10.1039/C6NR08220C
 N2  - Inkjet printing is a powerful and cost-effective technique for deposition of liquid inks with high accuracy, which is not only of great significance for graphic applications but also has enormous potential for the direct printing of optoelectronic devices. This review highlights a comprehensive overview of the progress that has been made in optoelectronics fabrication by the inkjet printing technique. The first part briefly covers the droplet-generation process in the nozzles of printheads and the physical properties affecting droplet formation and the profiles of the printed patterns. The second section outlines the recent activities related to applications of inkjet printing in optoelectronics fabrication including solar cells, light-emitting diodes, photodetectors and transparent electrodes. In each application field, the challenges with the inkjet printing process and the possible solutions are discussed before a few remarks. In the last section, a brief summary on the progress of inkjet printing fabrication of optoelectronics and an outlook for future research effort are presented.
 A1  - Zhan, Zhaoyao
 A1  - An, Jianing
@@ -265,7 +265,7 @@ PB  - The Royal Society of Chemistry
 SN  - current
 DO  - 10.1039/C5RA08205F
 M3  - 10.1039/C5RA08205F
-UR  - http://dx.doi.org/10.1039/C5RA08205F
+UR  - https://doi.org/10.1039/C5RA08205F
 N2  - Conductive inks are a recent advance in electronics and have promising future applications in flexible electronics and smart applications. In this review we tried to focus on a particular conductive ink that is based on copper nanoparticles. Although extensive research is being done all over the world, a few complications are yet to be perfectly solved. We tried to focus on some of the complications involved in their synthesis and their various applications in the different fields of science. Conductive inks have promising applications in the present trends of science and technology. The main intention behind this review is to list some of the best methods to synthesize copper nanoparticles according to the method of synthesizing them. We chose copper nanoparticle synthesis and the preparation of conductive inks because copper is a very abundant material, possesses high conductivity (after silver), and it has huge potential to replace expensive conductive inks made of silver, graphene, CNTs, etc. The other reason behind focussing on copper is its properties, such as ductility, malleability, thermal dissipation activity, anti-microbial nature, etc. In this review, we have listed some of the best methods of synthesizing copper conductive inks and their usage in various printing techniques. Different methods of sintering for the obtained conductive patterns are also included.
 A1  - K, Venkata Abhinav
 A1  - R, Venkata Krishna Rao
@@ -287,7 +287,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0959-9428
 DO  - 10.1039/A902652E
 M3  - 10.1039/A902652E
-UR  - http://dx.doi.org/10.1039/A902652E
+UR  - https://doi.org/10.1039/A902652E
 N2  - Solution-processable organic and polymeric semiconducting materials are active materials used for electronic devices such as thin film field-effect transistors (FETs). These materials are more likely to have practical advantages when coupled with low cost approaches to patterning that are compatible with them. Material requirements for high performance solution based FETs are discussed. Also described are structural, morphological, and processing factors that influence device performance. Finally, methods and schemes of printing workable devices are surveyed.
 A1  - Bao, Zhenan
 A1  - Rogers, John A.
@@ -308,7 +308,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C4CS00089G
 M3  - 10.1039/C4CS00089G
-UR  - http://dx.doi.org/10.1039/C4CS00089G
+UR  - https://doi.org/10.1039/C4CS00089G
 N2  - Metal organic frameworks (MOFs) offer the highest surface areas per gram of any known material. As such, they epitomise resource productivity in uses where specific surface area is critical, such as adsorption, storage, filtration and catalysis. However, the ability to control the position of MOFs is also crucial for their use in devices for applications such as sensing, delivery, sequestration, molecular transport, electronics, energy production, optics, bioreactors and catalysis. In this review we present the current technologies that enable the precise positioning of MOFs onto different platforms. Methods for permanent localisation, dynamic localisation, and spatial control of functional materials within MOF crystals are described. Finally, examples of devices in which the control of MOF position and functionalisation will play a major technological role are presented.
 A1  - Falcaro, Paolo
 A1  - Ricco, Raffaele
@@ -332,7 +332,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C7TC05271E
 M3  - 10.1039/C7TC05271E
-UR  - http://dx.doi.org/10.1039/C7TC05271E
+UR  - https://doi.org/10.1039/C7TC05271E
 N2  - A novel generation of flexible opto-electronic smart applications is now emerging, incorporating photovoltaic and sensing devices driven by the desire to extend and integrate such technologies into a broad range of low cost and disposable consumer products of our everyday life and as a tool to bring together the digital and physical worlds. Several flexible polymeric materials are now under investigation to be used as mechanical supports for such applications. Among them, cellulose, the most abundant organic polymer on the Earth, commonly used in the form of paper, has attracted much research interest due to the advantages of being recyclable, flexible, lightweight, biocompatible and extremely low-cost, when compared to other materials. Cellulose substrates can be found in many forms, from the traditional micro-cellulose paper used for writing, printing and food/beverage packaging (e.g. liquid packaging cardboard), to the nano-cellulose paper which has distinct structural, optical, thermal and mechanical properties that can be tailored to its end use. The present article reviews the state-of-the-art related to the integration and optimization of photonic structures and light harvesting technologies on paper-based platforms, for applications such as Surface Enhanced Raman Scattering (SERS), supporting remarkable 107 signal enhancement, and photovoltaic solar cells reaching ∼5% efficiency, for power supply in standalone applications. Such paper-supported technologies are now possible due to innovative coatings that functionalize the paper surfaces, together with advanced light management solutions (e.g. wave-optical light trapping structures and NIR-to-visible up-converters). These breakthroughs open the way for an innovative class of disposable opto-electronic products that can find widespread use and bring important added value to existing commercial products. By making these devices ubiquitous, flexible and conformable to any object or surface, will also allow them to become part of the core of the Internet of Things (IoT) revolution, which demands systems’ mobility and self-powering functionalities to satisfy the requirements of comfort and healthcare of the users.
 A1  - Vicente, António T.
 A1  - Araújo, Andreia
@@ -360,7 +360,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C4TC00618F
 M3  - 10.1039/C4TC00618F
-UR  - http://dx.doi.org/10.1039/C4TC00618F
+UR  - https://doi.org/10.1039/C4TC00618F
 N2  - This review deals with the use of solution processing approaches for organic electronics with a focus on material ink formulations as well as on their applicability. The solution processing techniques include methods like gravure printing, screen printing and ink-jet printing. Basic principles of each approach are understood and fundamental correlations between material (metals, semiconductors, and dielectrics) ink properties and final device performances can be drawn. Nevertheless, solution processing methods have the potential to evolve as the most promising tools in organic device fabrication techniques and have already been applied successfully in the fields of organic thin film transistors, solar cells and biosensing devices.
 A1  - Aleeva, Yana
 A1  - Pignataro, Bruno
@@ -380,7 +380,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C6NR03054H
 M3  - 10.1039/C6NR03054H
-UR  - http://dx.doi.org/10.1039/C6NR03054H
+UR  - https://doi.org/10.1039/C6NR03054H
 N2  - Since the last decade, interest in cellulose nanomaterials known as nanocellulose has been growing. Nanocellulose has various applications ranging from composite reinforcement to rheological modifiers. Recently, nanocellulose has been shown to have great potential in flexible printed electronics applications. The property of nanocellulose to form self-standing thermally stable films has been exploited for producing transparent and smooth substrates for printed electronics. However, other than substrates, the field of printed electronics involves the use of inks, various processing methods and the production of flexible electronic devices. This review aims at providing an overview of the use and potential of nanocellulose throughout the printed electronics field.
 A1  - Hoeng, Fanny
 A1  - Denneulin, Aurore
@@ -401,7 +401,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C4TA00716F
 M3  - 10.1039/C4TA00716F
-UR  - http://dx.doi.org/10.1039/C4TA00716F
+UR  - https://doi.org/10.1039/C4TA00716F
 N2  - Flexible batteries possess several unique features including high flexibility, lightweight and easy portability, high specific power and energy density, and remarkable rate capability, etc. So far, many different kinds of flexible batteries have been invented. The batteries, according to the electrochemical processes in a cell, can be categorized as flexible alkaline batteries, plastic batteries (or all-polymer batteries), polymer lithium-metal batteries (with lithium foil as an anode), and flexible rechargeable lithium ion batteries (LIBs), etc. Among these, flexible LIBs attract more rapidly increasing attention. As compared to the conventional rechargeable LIBs, fabrication of flexible LIBs is more challenging. An optimal match among the core components, i.e., nanostructured electrode materials, shape-conformable solid electrolytes, and soft current collectors should be achieved, so that the batteries maintain stable electrochemical performances even though they are deformed to fit the powered devices. Thus, fabrication of such batteries is not cost-effective and hence, is also inefficient. In the search for the potential core components for flexible LIBs, much progress has been made in screening solid state electrolytes, soft current collectors and electrode materials, and in electrode design and full LIB cell assembly (particularly in managing to get the three core components to work harmonically). There are also studies focusing on fundamental understanding and simulation of fully flexible LIBs. They reliably anticipate and describe the battery performances that are not easily explored experimentally using the present state-of-the-art technologies. In this review, we systematically summarize the advances in flexible LIBs research, with focus on the development of flexible electrodes. The review proceeds in terms of the processes for making electrodes and full LIB cells so as to emphasize the materials and process technologies. The development of solid state electrolytes and the fundamental understanding and simulation of flexible LIBs are also addressed. The review concludes with a perspective according to the author's experience in the related field, and the potential application of printing processes in flexible LIB fabrication is especially emphasized.
 A1  - Hu, Yuhai
 A1  - Sun, Xueliang
@@ -421,7 +421,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C6TC01979J
 M3  - 10.1039/C6TC01979J
-UR  - http://dx.doi.org/10.1039/C6TC01979J
+UR  - https://doi.org/10.1039/C6TC01979J
 N2  - Textile wearable electronics offer the consolidated advantages of both electronics and textile characteristics. Wearable electronic systems typically require conductive tracks as a platform to integrate electronic components. Herein we developed a site-selective electroless plating process to construct dual-side Cu patterns onto textile substrates. The proposed craft was mainly comprised of four procedures, namely, 3-aminopropyltrimethoxysilane (APTMS)-modification, wax-pattern printing, selective Au-seeding and Cu-pattern deposition. Specifically, waxes were transferred from commercial wax impregnated papers to APTMS modified fabrics with the aid of a conventional stylus printer. Intensive waxed dots then composed a wax pattern which corresponded to the input image designed on the computer. The wax pattern acted as a hydrophobic mask on the fabric surface and hindered the covered areas from being activated by subsequent Au catalysts. The non-covered areas, in contrast, were APTMS naked surfaces which normally adsorbed Au nanoparticles and had Cu tracks grown. The minimum width of the Cu track was 400 μm with 3.57% deviation and the typical resistivity was 7.52 μΩ cm, which was about 4.6 times that of the bulk metal Cu (at room temperature). The reliabilities of textile-based conductive Cu patterns were confirmed by air-exposure, ultrasonic washing and Scotch®-tape tests. In addition, the universality and versatility of the proposed method were validated by fabricating different metal patterns on various types of flexible substrates.
 A1  - Zhao, H.
 A1  - Hou, L.
@@ -443,7 +443,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C6TC03230C
 M3  - 10.1039/C6TC03230C
-UR  - http://dx.doi.org/10.1039/C6TC03230C
+UR  - https://doi.org/10.1039/C6TC03230C
 N2  - The emergence of smartphones and televisions with curved displays indicates that flexible organic light-emitting diodes (OLEDs) are marching steadily toward commercialization. Regardless of the significant step forward from laboratory to industry, flexible OLEDs are still facing enormous obstacles and challenges in realizing truly wearable, deformable, printable and low-cost electronic products for the future. How to develop highly flexible electrodes, optimize the device efficiency and greatly extend the operation lifetime are among the most important issues to be solved. In this regard, this review summarizes the recent achievements in flexible transparent conductive electrodes, device fabrication as well as light extraction technologies. Furthermore, the device operation stability is discussed with a focus on device degradation mechanisms and encapsulation methods. Some future prospects on new opportunities and research challenges in flexible OLEDs are also covered.
 A1  - Xu, Rui-Peng
 A1  - Li, Yan-Qing
@@ -464,7 +464,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C4TC01820F
 M3  - 10.1039/C4TC01820F
-UR  - http://dx.doi.org/10.1039/C4TC01820F
+UR  - https://doi.org/10.1039/C4TC01820F
 N2  - Well-defined high resolution structures with excellent electrical conductivities are key components of almost every electronic device. Producing these by printing metal based conductive inks on polymer foils represents an important step forward towards the manufacturing of plastic electronic products on an industrial scale. The development of fast, efficient and inexpensive post-deposition sintering technologies for these materials is an important processing step to make this approach commercially viable. This review discusses the advances in alternative sintering approaches for conductive, metal containing inks, which can be processed by inkjet-printing processes. Each sintering approach is examined regarding its mechanism, its compatibility with commonly used materials in the field of flexible electronics, its compatibility with high-throughput manufacturing processes and its applicability to the production of flexible electronic devices.
 A1  - Wünscher, Sebastian
 A1  - Abbel, Robert
@@ -486,7 +486,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C1CS15065K
 M3  - 10.1039/C1CS15065K
-UR  - http://dx.doi.org/10.1039/C1CS15065K
+UR  - https://doi.org/10.1039/C1CS15065K
 N2  - This critical review focuses on the solution deposition of transparent conductors with a particular focus on transparent conducting oxide (TCO) thin-films. TCOs play a critical role in many current and emerging opto-electronic devices due to their unique combination of electronic conductivity and transparency in the visible region of the spectrum. Atmospheric-pressure solution processing is an attractive alternative to conventional vacuum-based deposition methods due to its ease of fabrication, scalability, and potential to lower device manufacturing costs. An introduction into the applications of and material criteria for TCOs will be presented first, followed by a discussion of solution routes to these systems. Recent studies in the field will be reviewed according to their materials system. Finally, the challenges and opportunities for further enabling research will be discussed in terms of emerging oxide systems and non-oxide based transparent conductors (341 references).
 A1  - Pasquarelli, Robert M.
 A1  - Ginley, David S.
@@ -507,7 +507,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C3CS35501B
 M3  - 10.1039/C3CS35501B
-UR  - http://dx.doi.org/10.1039/C3CS35501B
+UR  - https://doi.org/10.1039/C3CS35501B
 N2  - Patterning of controllable surface wettability has attracted wide scientific attention due to its importance in both fundamental research and practical applications. In particular, it is crucial to form clear image areas and non-image areas in printing techniques based on wetting and dewetting. This review summarizes the recent research on and applications of patterning of controllable surface wettability for printing techniques, with a focus on the design and fabrication of the precise surface wettability patterning by enhancing the contrast of hydrophilicity and hydrophobicity, such as superhydrophilicity and superhydrophobicity. The selected topics mainly include patterned surface wettability for lithographic printing with different plate-making techniques, patterned surface wettability for microcontact printing with a patterned wetting stamp and special wettability mediated patterning microtransfer printing, patterned surface wettability for inkjet printing with controllable surface wettability of the substrate and printing head to ink, and patterned surface wettability by a combination of different printing techniques. A personal perspective on the future development and remaining challenges of this research is also briefly discussed.
 A1  - Tian, Dongliang
 A1  - Song, Yanlin
@@ -528,7 +528,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0003-2654
 DO  - 10.1039/B916888E
 M3  - 10.1039/B916888E
-UR  - http://dx.doi.org/10.1039/B916888E
+UR  - https://doi.org/10.1039/B916888E
 N2  - Advanced printing and deposition methodologies are revolutionising the way biological molecules are deposited and leading to changes in the mass production of biosensors and biodevices. This revolution is being delivered principally through adaptations of printing technologies to device fabrication, increasing throughputs, decreasing feature sizes and driving production costs downwards. This review looks at several of the most relevant deposition and patterning methodologies that are emerging, either for their high production yield, their ability to reach micro- and nano-dimensions, or both. We look at inkjet, screen, microcontact, gravure and flexographic printing as well as lithographies such as scanning probe, photo- and e-beam lithographies and laser printing. We also take a look at the emerging technique of plasma modification and assess the usefulness of these for the deposition of biomolecules and other materials associated with biodevice fabrication.
 A1  - Gonzalez-Macia, Laura
 A1  - Morrin, Aoife
@@ -550,7 +550,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C3TC31740D
 M3  - 10.1039/C3TC31740D
-UR  - http://dx.doi.org/10.1039/C3TC31740D
+UR  - https://doi.org/10.1039/C3TC31740D
 N2  - Flexible and printable electronics are attractive techniques which have potential for broad applications not only in flexible but also in large area electronics. An effective and convenient method of fabricating high-resolution copper patterns with high conductivity and strong adhesion on flexible photopaper is demonstrated in this paper. Functional photopaper was prepared with inkjet printing of a palladium salt solution onto its surface, followed by electroless deposition of copper. Parameters of the printing process, such as voltage control waveform, temperature of printhead and substrate, meniscus vacuum level, printing height, etc. were optimized to obtain a robust and high resolution printing with feature dimensions down to 50 μm. Through a unique thermal sintering process, printed copper lines showed excellent conductivity of up to 3.9 × 107 S m−1 (>65% of bulk copper). The developed technique was successfully applied for fabricating paper based functional flexible circuits such as RFID antennae, micro-inductive coils and complex circuit boards.
 A1  - Zhang, Tengyuan
 A1  - Wang, Xiaolong
@@ -573,7 +573,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0003-2654
 DO  - 10.1039/C4AN00646A
 M3  - 10.1039/C4AN00646A
-UR  - http://dx.doi.org/10.1039/C4AN00646A
+UR  - https://doi.org/10.1039/C4AN00646A
 N2  - A flexible and disposable strip sensor for non-enzymatic glucose detection is demonstrated in this work. The strips are prepared by using chemical modification processes followed by a simple electroless deposition of copper. Essentially, polyester overhead projector (OHP) transparent films are modified with a monolayer of 3-aminopropyltrimethoxysilane (APTMS) and polyaniline (PANI) conducting polymer. Later, nanostructured copper is deposited onto this modified film. Scanning electron microscope (SEM) and X-ray diffraction (XRD) studies are used for the structural, morphological and crystallinity characterization of the modified films. Electrochemical techniques, namely cyclic voltammetry (CV) and chronoamperometry (CA), are employed for the non-enzymatic detection of glucose. These studies clearly reveal the formation of homogeneous, close-packed spherical Cu particles converged into uniform film that exhibits a good catalytic activity towards the oxidation of glucose. The Cu/PANI/APTMS/OHP sensor displays a remarkable enhancement in the oxidation current density, a very high sensitivity value of 2.8456 mA cm−2 per mM, and a linear concentration range from 100 μM to 6.5 mM associated with glucose detection. Detection limit is estimated to be 5 μM and the response time of the sensor is determined to be less than 5 s. For comparison, similar studies are performed without PANI, namely Cu/APTMS/OHP films for glucose detection. In this case, a sensitivity value of 2.4457 mA cm−2 per mM and a linear concentration range of 100 μM–3 mM are estimated. The higher performance characteristics observed in the case of Cu/PANI/APTMS/OHP are attributed to the synergistic effects of the conducting polymer acting as an electron facilitator and the nanostructured Cu films. These disposable, flexible and low-cost strip sensors have also been applied to the detection of glucose in clinical blood serum samples and the results obtained agree very well with the actual glucose level.
 A1  - Thota, Raju
 A1  - Ganesh, V.
@@ -593,7 +593,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C2CS15335A
 M3  - 10.1039/C2CS15335A
-UR  - http://dx.doi.org/10.1039/C2CS15335A
+UR  - https://doi.org/10.1039/C2CS15335A
 N2  - Semiconducting inorganic nanowires (NWs), nanotubes and nanofibers have been extensively explored in recent years as potential building blocks for nanoscale electronics, optoelectronics, chemical/biological/optical sensing, and energy harvesting, storage and conversion, etc. Besides the top-down approaches such as conventional lithography technologies, nanowires are commonly grown by the bottom-up approaches such as solution growth, template-guided synthesis, and vapor–liquid–solid process at a relatively low cost. Superior performance has been demonstrated using nanowires devices. However, most of the nanowire devices are limited to the demonstration of single devices, an initial step toward nanoelectronic circuits, not adequate for production on a large scale at low cost. Controlled and uniform assembly of nanowires with high scalability is still one of the major bottleneck challenges towards the materials and device integration for electronics. In this review, we aim to present recent progress toward nanowire device assembly technologies, including flow-assisted alignment, Langmuir–Blodgett assembly, bubble-blown technique, electric/magnetic- field-directed assembly, contact/roll printing, planar growth, bridging method, and electrospinning, etc. And their applications in high-performance, flexible electronics, sensors, photovoltaics, bioelectronic interfaces and nano-resonators are also presented.
 A1  - Long, Yun-Ze
 A1  - Yu, Miao
@@ -616,7 +616,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1463-9076
 DO  - 10.1039/C4CP02413C
 M3  - 10.1039/C4CP02413C
-UR  - http://dx.doi.org/10.1039/C4CP02413C
+UR  - https://doi.org/10.1039/C4CP02413C
 N2  - Organic electronics is regarded as an important branch of future microelectronics especially suited for large-area, flexible, transparent, and green devices, with their low cost being a key benefit. Organic field-effect transistors (OFETs), the primary building blocks of numerous expected applications, have been intensively studied, and considerable progress has recently been made. However, there are still a number of challenges to the realization of high-performance OFETs and integrated circuits (ICs) using printing technologies. Therefore, in this perspective article, we investigate the main issues concerning developing high-performance printed OFETs and ICs and seek strategies for further improvement. Unlike many other studies in the literature that deal with organic semiconductors (OSCs), printing technology, and device physics, our study commences with a detailed examination of OFET performance parameters (e.g., carrier mobility, threshold voltage, and contact resistance) by which the related challenges and potential solutions to performance development are inspected. While keeping this complete understanding of device performance in mind, we check the printed OFETs' components one by one and explore the possibility of performance improvement regarding device physics, material engineering, processing procedure, and printing technology. Finally, we analyze the performance of various organic ICs and discuss ways to optimize OFET characteristics and thus develop high-performance printed ICs for broad practical applications.
 A1  - Xu, Yong
 A1  - Liu, Chuan
@@ -638,7 +638,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1463-9076
 DO  - 10.1039/C8EE01979G
 M3  - 10.1039/C8EE01979G
-UR  - http://dx.doi.org/10.1039/C8EE01979G
+UR  - https://doi.org/10.1039/C8EE01979G
 N2  - Although integrated energy storage devices, such as in-plane micro-supercapacitors (MSCs), are attractive for powering portable microelectronic devices, it is still challenging to develop patterning techniques with high practicability and to rationally design and fabricate electrochemically active materials using feasible procedures. Here, we propose a facile solution-immersion method of fabricating interdigitated copper electrodes with an in situ converted array of Cu(OH)2@FeOOH nanotubes (NTs). A copper current collector can be patterned together with widely employed copper circuits by a facile copper-patterning approach based on cost-effective electroless catalytic deposition of copper with patterned Ag catalysts, which is greatly conducive to the integration of in-plane energy storage devices into microelectronic systems. Furthermore, the rationally designed array of Cu(OH)2@FeOOH NTs, which was converted in situ from the patterned copper electrodes, was demonstrated to be an excellent electrochemically active material with advantages that included a porous structure with a large specific surface area, excellent wettability by the electrolyte, short ion diffusion lengths and one-dimensional electron transport pathway. The resulting MSC devices that were fabricated with the interdigitated Cu(OH)2@FeOOH/Cu electrodes exhibited a high specific capacitance (58.0 mF cm−2 at 0.1 mA cm−2), a high energy density (18.07 μW h cm−2), excellent cycling stability and desirable flexibility.
 A1  - Xie, Jin-Qi
 A1  - Ji, Ya-Qiang
@@ -664,7 +664,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C5TC01421B
 M3  - 10.1039/C5TC01421B
-UR  - http://dx.doi.org/10.1039/C5TC01421B
+UR  - https://doi.org/10.1039/C5TC01421B
 N2  - Conventional electronic circuit wiring methods involve subtractive processes such as etching the copper foils, and thus are inefficient and cause serious environmental problems. Printed electronics technology is expected to be more environmentally benign and have lower cost, due to its additive characteristics. In this paper, we present a simple and efficient strategy to fabricate high performance copper metal fine circuits by a galvanic replacement deposition method. Zinc nanoparticles filled epoxy resin paste is printed onto the substrate film as the seed layer; with a subsequent simple galvanic replacement reaction between Zn and Cu2+, we can obtain a conductive Cu layer that can be further thickened by electroplating. The as-prepared circuits show bulk Cu conductivity, excellent flexibility, adhesion strength and pattern resolution. By adjusting the processing parameters, this technology is suitable for various practical applications, such as flexible circuit boards, RFID tags, touch panels, membrane switches, and photovoltaics, making it a promising solution for low-cost and environmentally friendly fabrication for flexible electronic devices.
 A1  - Liu, Jingping
 A1  - Yang, Cheng
@@ -691,7 +691,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C7CS00490G
 M3  - 10.1039/C7CS00490G
-UR  - http://dx.doi.org/10.1039/C7CS00490G
+UR  - https://doi.org/10.1039/C7CS00490G
 N2  - Organic semiconductors have attracted a lot of attention since the discovery of highly doped conductive polymers, due to the potential application in field-effect transistors (OFETs), light-emitting diodes (OLEDs) and photovoltaic cells (OPVs). Single crystals of organic semiconductors are particularly intriguing because they are free of grain boundaries and have long-range periodic order as well as minimal traps and defects. Hence, organic semiconductor crystals provide a powerful tool for revealing the intrinsic properties, examining the structure–property relationships, demonstrating the important factors for high performance devices and uncovering fundamental physics in organic semiconductors. This review provides a comprehensive overview of the molecular packing, morphology and charge transport features of organic semiconductor crystals, the control of crystallization for achieving high quality crystals and the device physics in the three main applications. We hope that this comprehensive summary can give a clear picture of the state-of-art status and guide future work in this area.
 A1  - Wang, Chengliang
 A1  - Dong, Huanli
@@ -713,7 +713,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C6TC03315F
 M3  - 10.1039/C6TC03315F
-UR  - http://dx.doi.org/10.1039/C6TC03315F
+UR  - https://doi.org/10.1039/C6TC03315F
 N2  - A convenient and efficient approach for selective metallization of alumina ceramics has been developed. The Ag+-bearing ink was firstly inkjet-printed on alumina ceramics to create catalytic activating layers for subsequent electroless copper plating (ECP), and then ECP was initiated to fabricate the desirable conductive patterns. A continuous copper layer with dense packing could be obtained by controlling the electroless plating process. A low resistivity of about 2.37 μΩ cm of the copper layer was achieved, which was only about 1.4 times higher than that of bulk copper. Moreover, such a copper layer exhibited satisfactory solderability, reliable adhesion to substrates and good stability in an ambient atmosphere. This approach proposed a potential way to realize surface metallization on ceramic substrates without high temperature and any sophisticated equipment.
 A1  - Chen, Jin-ju
 A1  - Guo, Yan-long
@@ -737,7 +737,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C6TC01625A
 M3  - 10.1039/C6TC01625A
-UR  - http://dx.doi.org/10.1039/C6TC01625A
+UR  - https://doi.org/10.1039/C6TC01625A
 N2  - Fabrication of electronic components or circuits by depositing conductive inks on organic or inorganic substrates is a preferred method for manufacturing flexible electronics due to its low cost and versatility. In recent years considerable research has been carried out to synthesize graphene and graphene related hybrid inks for various applications in components and circuits for flexible electronics. In this paper the development of graphene and graphene hybrid inks is reviewed, with particular focus on their formulation, properties and applications. The challenges are also discussed and further development should be focused on ink formulation and preparation methods for low cost and eco-friendly manufacture, easy patterning and processing with good film conductivity. The rational combination of ink formulation and pattern deposition methods would be a direction to follow in the future development of graphene and related inks for commercial application in flexible electronics.
 A1  - Yang, Wendong
 A1  - Wang, Changhai
@@ -757,7 +757,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C5TA05666G
 M3  - 10.1039/C5TA05666G
-UR  - http://dx.doi.org/10.1039/C5TA05666G
+UR  - https://doi.org/10.1039/C5TA05666G
 N2  - Recent developments in the field of energy storage materials are expected to provide sustainable solutions to the problems related to energy density and storage. The increasing energy demand for next generation portable and miniaturized electronic devices has sparked intensive interest to explore micro-scale and lightweight energy storage devices. This critical review provides an overview of the state-of-the-art recent research advances in micro-scale energy storage devices for supercapacitors (SCs), as well as their future importance in technology. Much effort has been devoted to fabricate high performance, ultrathin, planar, solid state and flexible micro-supercapacitors (MSCs) with aesthetic appeal. Nano-materials for MSCs, their fabrication techniques and performances are critically analyzed. The technical challenges and perspectives for MSCs are also discussed. The review concludes with few suggestions for future advancements in this area.
 A1  - Tyagi, Ankit
 A1  - Tripathi, Kumud Malika
@@ -778,7 +778,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0003-2654
 DO  - 10.1039/C6AN00210B
 M3  - 10.1039/C6AN00210B
-UR  - http://dx.doi.org/10.1039/C6AN00210B
+UR  - https://doi.org/10.1039/C6AN00210B
 N2  - Rapid prototyping is a critical step in the product development cycle of miniaturized chemical and bioanalytical devices, often categorized as lab-on-a-chip devices, biosensors, and micro-total analysis systems. While high throughput manufacturing methods are often preferred for large-volume production, rapid prototyping is necessary for demonstrating and predicting the performance of a device and performing field testing and validation before translating a product from research and development to large volume production. Choosing a specific rapid prototyping method involves considering device design requirements in terms of minimum feature sizes, mechanical stability, thermal and chemical resistance, and optical and electrical properties. A rapid prototyping method is then selected by making engineering trade-off decisions between the suitability of the method in meeting the design specifications and manufacturing metrics such as speed, cost, precision, and potential for scale up. In this review article, we review four categories of rapid prototyping methods that are applicable to developing miniaturized bioanalytical devices, single step, mask and deposit, mask and etch, and mask-free assembly, and we will focus on the trade-offs that need to be made when selecting a particular rapid prototyping method. The focus of the review article will be on the development of systems having a specific arrangement of conductive or semiconductive materials.
 A1  - Gabardo, C. M.
 A1  - Soleymani, L.
@@ -798,7 +798,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0003-2654
 DO  - 10.1039/C8CS00609A
 M3  - 10.1039/C8CS00609A
-UR  - http://dx.doi.org/10.1039/C8CS00609A
+UR  - https://doi.org/10.1039/C8CS00609A
 N2  - Gold, one of the noble metals, has played a significant role in human society throughout history. Gold's excellent electrical, optical and chemical properties make the element indispensable in maintaining a prosperous modern electronics industry. In the emerging field of stretchable electronics (elastronics), the main challenge is how to utilize these excellent material properties under various mechanical deformations. This review covers the recent progress in developing “softening” gold chemistry for various applications in elastronics. We systematically present material synthesis and design principles, applications, and challenges and opportunities ahead.
 A1  - Zhu, Bowen
 A1  - Gong, Shu
@@ -819,7 +819,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C4CS00116H
 M3  - 10.1039/C4CS00116H
-UR  - http://dx.doi.org/10.1039/C4CS00116H
+UR  - https://doi.org/10.1039/C4CS00116H
 N2  - Flexible electronics have gained considerable research interest in the recent years because of their special features and potential applications in flexible displays, artificial skins, sensors, sustainable energy, etc. With unique geometry, outstanding electronic/optoelectronic properties, excellent mechanical flexibility and good transparency, inorganic nanowires (NWs) offer numerous insights and opportunities for flexible electronics. This article provides a comprehensive review of the inorganic NW based flexible electronics studied in the past decade, ranging from NWs synthesis and assembly to several important flexible device and energy applications, including transistors, sensors, display devices, memories and logic gates, as well as lithium ion batteries, supercapacitors, solar cells and generators. The integration of various flexible nanodevices into a self-powered system was also briefly discussed. Finally, several future research directions and opportunities of inorganic NW flexible and portable electronics are proposed.
 A1  - Liu, Zhe
 A1  - Xu, Jing
@@ -841,7 +841,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C7CS00122C
 M3  - 10.1039/C7CS00122C
-UR  - http://dx.doi.org/10.1039/C7CS00122C
+UR  - https://doi.org/10.1039/C7CS00122C
 N2  - Metal–organic frameworks (MOFs) are typically highlighted for their potential application in gas storage, separations and catalysis. In contrast, the unique prospects these porous and crystalline materials offer for application in electronic devices, although actively developed, are often underexposed. This review highlights the research aimed at the implementation of MOFs as an integral part of solid-state microelectronics. Manufacturing these devices will critically depend on the compatibility of MOFs with existing fabrication protocols and predominant standards. Therefore, it is important to focus in parallel on a fundamental understanding of the distinguishing properties of MOFs and eliminating fabrication-related obstacles for integration. The latter implies a shift from the microcrystalline powder synthesis in chemistry labs, towards film deposition and processing in a cleanroom environment. Both the fundamental and applied aspects of this two-pronged approach are discussed. Critical directions for future research are proposed in an updated high-level roadmap to stimulate the next steps towards MOF-based microelectronics within the community.
 A1  - Stassen, Ivo
 A1  - Burtch, Nicholas
@@ -865,7 +865,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0959-9428
 DO  - 10.1039/C2JM31381B
 M3  - 10.1039/C2JM31381B
-UR  - http://dx.doi.org/10.1039/C2JM31381B
+UR  - https://doi.org/10.1039/C2JM31381B
 N2  - Ink-jet printed conductive copper patterns with enhanced substrate adhesion were fabricated using a conductive copper ink containing a silane coupling agent as an adhesion promoter. The effect of the silane coupling agent on the copper complex ion ink properties, including viscosity and surface tension, was systematically investigated. The copper complex ion ink that was ink-jet printed on a polyimide film was transformed to copper films by thermal treatment at 200 °C for 2 h in H2. The phase, microstructure, resistivity and peel strength were examined by X-ray diffraction, field emission scanning electron microscopy, the four-point probe technique, the 90° peel test and the ASTM D3359 tape test. The proper amount of silane coupling agent was determined according to the electrical conductivities and adhesive strengths of the ink-jet printed copper patterns containing varied amounts of adhesion promoter. As a result, the patterns formed from copper complex ion ink containing 3 wt% silane coupling agent exhibited not only the highest peel strength (240.3 gf mm−1 and 4B) but also low resistivity (approx. 20 μΩ cm). The mechanism of adhesion promotion via the silane coupling agent was also suggested.
 A1  - Lee, Young-In
 A1  - Choa, Yong-Ho
@@ -885,7 +885,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1759-9954
 DO  - 10.1039/B9PY00281B
 M3  - 10.1039/B9PY00281B
-UR  - http://dx.doi.org/10.1039/B9PY00281B
+UR  - https://doi.org/10.1039/B9PY00281B
 N2  - Microcontact printing (μCP) is a straightforward method for the preparation of micro- and nanostructured surfaces. The key element in μCP is a polymeric stamp with a relief pattern. This stamp is “inked” and put in contact with the substrate surface. Ideally, the ink is transferred from stamp to substrate only in the area of contact. This review focuses on the important role of polymers in μCP. First of all, polymers are the material of choice to make μCP stamps. Furthermore, μCP is a useful method for preparing microstructured polymer surfaces. Polymers can be applied as inks in μCP so that microstructured polymer surfaces are obtained in a single printing step. Microstructured polymer surfaces can also be obtained by μCP on polymer substrates. A wide range of inks – including polymer inks – can be patterned on polymer substrates by μCP. In short, polymers are widely used as stamps, inks and substrates in μCP and we have organized this review accordingly.
 A1  - Kaufmann, Tobias
 A1  - Ravoo, Bart Jan
@@ -905,7 +905,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C7CS00505A
 M3  - 10.1039/C7CS00505A
-UR  - http://dx.doi.org/10.1039/C7CS00505A
+UR  - https://doi.org/10.1039/C7CS00505A
 N2  - Flexible solid-state supercapacitors (FSSCs) are frontrunners in energy storage device technology and have attracted extensive attention owing to recent significant breakthroughs in modern wearable electronics. In this study, we review the state-of-the-art advancements in FSSCs to provide new insights on mechanisms, emerging electrode materials, flexible gel electrolytes and novel cell designs. The review begins with a brief introduction on the fundamental understanding of charge storage mechanisms based on the structural properties of electrode materials. The next sections briefly summarise the latest progress in flexible electrodes (i.e., freestanding and substrate-supported, including textile, paper, metal foil/wire and polymer-based substrates) and flexible gel electrolytes (i.e., aqueous, organic, ionic liquids and redox-active gels). Subsequently, a comprehensive summary of FSSC cell designs introduces some emerging electrode materials, including MXenes, metal nitrides, metal–organic frameworks (MOFs), polyoxometalates (POMs) and black phosphorus. Some potential practical applications, such as the development of piezoelectric, photo-, shape-memory, self-healing, electrochromic and integrated sensor-supercapacitors are also discussed. The final section highlights current challenges and future perspectives on research in this thriving field.
 A1  - Dubal, Deepak P.
 A1  - Chodankar, Nilesh R.
@@ -927,7 +927,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C6TA05286J
 M3  - 10.1039/C6TA05286J
-UR  - http://dx.doi.org/10.1039/C6TA05286J
+UR  - https://doi.org/10.1039/C6TA05286J
 N2  - Thin-film solar technology is the subject of considerable current research. The classical material platform of amorphous silicon (a-Si) has been complemented by organic solar cells and more recently by solar cells based on quantum dots or organo-metal-halide perovskites. The majority of effort is focused on the synthesis, characterization and optimization of the photo-active components as well as on the invention of novel device architectures. Low-cost, low-weight, flexibility and the opportunity to create semi-transparent devices are among the most frequently claimed selling points of thin-film solar cells. It is clear that the full potential of this technology and the ability to fulfill its promises are intimately linked with tailored concepts for transparent electrodes beyond established avenues. Transparent electrodes, that can be realized at a large area, at low costs, at low temperature, which are flexible (or even elastic), and which afford a conductivity and transmittance even better than those of indium-tin-oxide, are still vigorously pursued. Even though metal based semi-transparent electrodes have a notable history, there is an ever increasing effort to unlock the full potential of metal nano-structures, especially ultra-thin films (2D) or metal-nanowires (1D) as semitransparent electrodes for thin-film solar cells. This article will review the most recent advances in semitransparent electrodes based on metal-nanowires or metal thin-films. Aside from providing general considerations and a review of the state of the art of electrode properties like sheet resistance and optical transmittance, we aim to highlight the current efforts to introduce these electrodes into solar cells. We will demonstrate that by the use of metal based semitransparent electrodes not only a replacement for established transparent conductors can be achieved but also novel functionalities can be envisaged.
 A1  - Zilberberg, Kirill
 A1  - Riedl, Thomas
@@ -947,7 +947,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1754-5692
 DO  - 10.1039/C6EE01137C
 M3  - 10.1039/C6EE01137C
-UR  - http://dx.doi.org/10.1039/C6EE01137C
+UR  - https://doi.org/10.1039/C6EE01137C
 N2  - Perovskite solar cells have attracted enormous interest since their discovery only a few years ago because they are able to combine the benefits of high efficiency and remarkable ease of processing over large areas. Whereas most of research has been carried out on glass, perovskite deposition and synthesis is carried out at low temperatures (<150 °C) to convert precursors into its final semiconducting form. Thus, developing the technology on flexible substrates can be considered a suitable and exciting arena both from the manufacturing view point (e.g. web processing, low embodied energy manufacturing) and that of the applications (e.g. flexible, lightweight, portable, easy to integrate over both small, large and curved surfaces). Research has been accelerating on flexible PSCs and has achieved notable milestones including PCEs of 15.6% on laboratory cells, the first modules being manufactured, ultralight cells with record power per gram ratios, and even cells made on fibres. Reviewing the literature, it becomes apparent that more work can be carried out in closing the efficiency gap with glass based counterparts especially at the large-area module level and, in particular, investigating and improving the lifetime of these devices which are built on inherently permeable plastic films. Here we review and provide a perspective on the issues pertaining progress in materials, processes, devices, industrialization and costs of flexible perovskite solar cells.
 A1  - Giacomo, Francesco Di
 A1  - Fakharuddin, Azhar
@@ -969,7 +969,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C7TA07856K
 M3  - 10.1039/C7TA07856K
-UR  - http://dx.doi.org/10.1039/C7TA07856K
+UR  - https://doi.org/10.1039/C7TA07856K
 N2  - In past decades, with interest in wearable smart devices rapidly growing, the design and fabrication of novel energy storage devices have received increasing attention. Although secondary batteries are among the best options in this area, their bulky construction remains unable to fulfil the specific demands of miniaturization, portability, and flexibility. This review comprises a brief update on recent progress in printable secondary batteries, in combination with their principles and frequently used printing techniques. Moreover, we also discuss the challenges and advantages of printed secondary batteries and describe their future prospects in wearable smart devices.
 A1  - Du, Cheng-Feng
 A1  - Liang, Qinghua
@@ -992,7 +992,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C7TC01848G
 M3  - 10.1039/C7TC01848G
-UR  - http://dx.doi.org/10.1039/C7TC01848G
+UR  - https://doi.org/10.1039/C7TC01848G
 N2  - Recently, intense pulsed light (IPL), also referred to as flash lamp annealing, has gained interest among materials scientists as a highly effective photonic technology for structural reformation and/or chemical modification of various nanomaterials. Split-second exposure of IPL on advanced materials of various compositions, including ceramics, metals, and carbon, and various structures, including nanoparticles, nanowires, and thin films, resulted in dramatic changes in the morphologies and chemical functional groups of the materials. Compared to conventional thermal heating and established photonic technologies such as lasers, IPL technologies have considerable advantages, such as facile equipment set-up, surface-selective treatment, large treatment area, short process times ranging from milliseconds to a few seconds, and roll-to-roll process compatibility. In this review, recent advances in the structural development and/or chemical modifications of various nanomaterials by IPL irradiation will be highlighted.
 A1  - Lim, Ho Sun
 A1  - Kim, Soo Jin
@@ -1014,7 +1014,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C6TC03719D
 M3  - 10.1039/C6TC03719D
-UR  - http://dx.doi.org/10.1039/C6TC03719D
+UR  - https://doi.org/10.1039/C6TC03719D
 N2  - A particle-free silver precursor ink suitable for inkjet printing was developed using silver citrate as the functional material and ethylenediamine as the complex solvent. The long-term storage stability and satisfactory printability of this ink have been proved and it was successfully printed on a flexible polyimide slice using a commercial printer. Its efficient catalytic activation for subsequent electroless plating was confirmed by the rapid growth of copper layers, and the resulting copper layer exhibited a compact, uniform and well-crystallized structure. The electrical resistivity as low as 2.80 μΩ cm (1.67 times larger than that of bulk copper) and adhesion on a polyimide substrate as high as 5B category according to the ASTM D-3359 could be achieved for the copper layer. In addition, copper tracks as narrow as 61 μm could be obtained based on the inkjet printing of this ink followed by electroless plating. These results suggest the great potential of this particle-free precursor ink in the field of flexible printed electronics.
 A1  - Chen, Jin-ju
 A1  - Zhang, Jing
@@ -1037,7 +1037,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1754-5692
 DO  - 10.1039/C7EE00826K
 M3  - 10.1039/C7EE00826K
-UR  - http://dx.doi.org/10.1039/C7EE00826K
+UR  - https://doi.org/10.1039/C7EE00826K
 N2  - Copper indium gallium selenide (CIGS) based solar cells are receiving worldwide attention for solar power generation. They are efficient thin film solar cells that have achieved 22.8% efficiency comparable to crystalline silicon (c-Si) wafer based solar cells. For a production capacity of 1000 MW y−1 with 15% module efficiency, the CIGS module production cost is expected to be $0.34 W−1. For CIGS cells over glass, a graded bandgap high temperature deposition process has been established, however, this process has not been established for CIGS over flexible polymer substrates which is a low temperature process. For small area devices, the main focus is precise control over CIGS film stoichiometry and efficiency. For industrial production, apart from stoichiometry and efficiency, low-cost, reproducibility, high-throughput and process tolerance are of much importance in commercializing the technology. Due to process complexity, CIGS module production is lagging behind that of cadmium telluride (CdTe) modules. In this review article, the working mechanism of CIGS solar cells with a back surface field, the importance of developing CIGS solar cells, and the limitations for their commercialization are discussed. CIGS solar cells are compared with c-Si solar cells. After briefly reviewing the history of the chalcopyrite alloy system, graded bandgaps, effects of sodium distribution in CIGS layers, growth of CIGS layers using various techniques, role of buffer layer/transparent conducting oxides, CdS free buffer layers, concerns related to flexible solar cells, and factors affecting the cell efficiency are reviewed. Further efficiency improvement options are discussed. Cell stability, challenges, solutions and future prospects of CIGS solar cells are outlined.
 A1  - Ramanujam, Jeyakumar
 A1  - Singh, Udai P.
@@ -1057,7 +1057,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C7TC01353A
 M3  - 10.1039/C7TC01353A
-UR  - http://dx.doi.org/10.1039/C7TC01353A
+UR  - https://doi.org/10.1039/C7TC01353A
 N2  - In this study, a novel scribing–seeding–plating (SSP) process for the fabrication of copper circuits with a strong adhesion strength of 39.68 N cm−1 and a high conductivity of 4.69 × 107 S m−1 (about 82.33% of bulk copper) onto flexible sandpaper substrates was developed. Specifically, a simple 450 nm blue laser pulse was firstly employed to scribe and modify the sandpaper surface, which caused the in situ generation of hydrophilic groups and ablated grooves. Then, Au catalytic nanoparticles were seeded on the laser direct scribing zones and subsequently catalyzed the electroless copper plating. The processing parameters were optimized by the Box–Behnken response surface methodology to obtain the optimal adhesion strength, and the best local maximum was found to be at 610.56 # for the mesh number of the sandpaper, a laser fluence of 15.38 J cm−2, a scanning speed of 300.00 mm s−1, and a scanning line interval of 13.21 μm. Remarkably, the optimized sandpaper-based Cu circuits maintained good anti-oxidation performance, favorable adhesion and reliable flexibility even after over 1000 bending or folding cycles. This environmentally friendly and effective SSP process for fabricating copper circuits onto sandpaper has great potential applications in flexible printed circuits and low-cost RFID tags.
 A1  - Hou, L.
 A1  - Zhao, H.
@@ -1079,7 +1079,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C3TC00572K
 M3  - 10.1039/C3TC00572K
-UR  - http://dx.doi.org/10.1039/C3TC00572K
+UR  - https://doi.org/10.1039/C3TC00572K
 N2  - Enormous efforts have been made towards the next generation of flexible, low-cost, environmentally benign printed electronics. In this regard, advanced materials for the printed conductive lines and interconnects are of significant importance. To improve efficiency and effectiveness, for several decades, conductive fillers have been filled into dispersants, which lead to the so-called electrically conductive composites (ECCs), which are a key material to the printed electronics varying from substituting the traditional solders to finding new applications in the blooming field of flexible printed electronics. ECCs in various formulations have converged in the current efforts to develop platforms with the desired specifications of electrical and thermal conductance, mechanical strength, and others. This platform is highly versatile and valuable for the emerging novel electronic devices, which emphasize tailoring processing conditions to cater to the key functional materials to optimize outcomes. The properties obtained can facilitate decisions about modifications to treatment. Noble metal fillers, such as silver flakes, have long been studied as active fillers for the ECCs. Owing to the recent progress in nanotechnology and surface modifications, many new avenues have opened for them. By taking advantage of the well-developed surface chemistry of these materials, researchers are enhancing their electrical conductivity, which is essential for broader applications. In recent years, the advances of ECCs have benefited the development of the applications of optoelectronics, e-papers, electromagnetic shielding, clinical diagnosis, radio frequency devices, etc. Despite the various advantages that they can offer over the traditional technologies, their limitations, e.g. low electrical conductivity, poor impact strength, increased contact resistance at elevated temperatures and humidity aging, have been considered as the major obstacles. In this feature article, we introduce the surface engineering techniques of the conductive filler materials that we and others have developed, with an emphasis on how these techniques influence the performance of the ECCs, especially for the improvement of the filler-to-filler electron transfer in the resin dispersants, some of which have potentially been approaching the theoretical upper limit of what they can reach in electrical conductivity. We and others have developed a set of chemical and engineering methods to modify the conductive fillers, enabling tailor-made surface functionalities and charges. These features, in turn, can be harnessed to adjust the electrical property and reliability of the ECCs, and further, to cater to various novel printed electronics, based on e.g. low temperature processing conditions.
 A1  - Yang, Cheng
 A1  - Wong, Ching Ping
@@ -1100,7 +1100,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C5NR06965C
 M3  - 10.1039/C5NR06965C
-UR  - http://dx.doi.org/10.1039/C5NR06965C
+UR  - https://doi.org/10.1039/C5NR06965C
 N2  - Counterfeiting of valuable documents, currency and branded products is a challenging problem that has serious economic, security and health ramifications for governments, businesses and consumers all over the world. It is estimated that counterfeiting represents a multi-billion dollar underground economy with counterfeit products being produced on a large scale every year. Counterfeiting is an increasingly high-tech crime and calls for high-tech solutions to prevent and deter the acts of counterfeiting. The present review briefly outlines and addresses the key challenges in this area, including the above mentioned concerns for anti-counterfeiting applications. This article describes a unique combination of all possible kinds of security ink formulations based on lanthanide doped luminescent nanomaterials, quantum dots (semiconductor and carbon based), metal organic frameworks as well as plasmonic nanomaterials for their possible use in anti-counterfeiting applications. Moreover, in this review, we have briefly discussed and described the historical background of luminescent nanomaterials, basic concepts and detailed synthesis methods along with their characterization. Furthermore, we have also discussed the methods adopted for the fabrication and design of luminescent security inks, various security printing techniques and their anti-counterfeiting applications.
 A1  - Kumar, Pawan
 A1  - Singh, Satbir
@@ -1121,7 +1121,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1473-0197
 DO  - 10.1039/C8LC00025E
 M3  - 10.1039/C8LC00025E
-UR  - http://dx.doi.org/10.1039/C8LC00025E
+UR  - https://doi.org/10.1039/C8LC00025E
 N2  - Flexible biosensors represent an increasingly important and rapidly developing field of research. Flexible materials offer several advantages as supports of biosensing platforms in terms of flexibility, weight, conformability, portability, cost, disposability and scope for integration. On the other hand, electrochemical detection is perfectly suited to flexible biosensing devices. The present paper reviews the field of integrated electrochemical bionsensors fabricated on flexible materials (plastic, paper and textiles) which are used as functional base substrates. The vast majority of electrochemical flexible lab-on-a-chip (LOC) biosensing devices are based on plastic supports in a single or layered configuration. Among these, wearable devices are perhaps the ones that most vividly demonstrate the utility of the concept of flexible biosensors while diagnostic cards represent the state-of-the art in terms of integration and functionality. Another important type of flexible biosensors utilize paper as a functional support material enabling the fabrication of low-cost and disposable paper-based devices operating on the lateral flow, drop-casting or folding (origami) principles. Finally, textile-based biosensors are beginning to emerge enabling real-time measurements in the working environment or in wound care applications. This review is timely due to the significant advances that have taken place over the last few years in the area of LOC biosensors and aims to direct the readers to emerging trends in this field.
 A1  - Economou, Anastasios
 A1  - Kokkinos, Christos
@@ -1142,7 +1142,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C4NR06816E
 M3  - 10.1039/C4NR06816E
-UR  - http://dx.doi.org/10.1039/C4NR06816E
+UR  - https://doi.org/10.1039/C4NR06816E
 N2  - Recently, various functional devices based on printing technologies have been of paramount interest, owing to their characteristic processing advantages along with excellent device performance. In particular, printable metallic electrodes have drawn attention in a variety of optoelectronic applications; however, research into printable metallic nanoparticles has been limited mainly to the case of an environmentally stable Ag phase. Despite its earth-abundance and highly conductive nature, the Cu phase, to date, has not been exploited as an ambient atmosphere-processable, printable material due to its critical oxidation problem in air. In this study, we demonstrate a facile route for generating highly conductive, flexible Cu electrodes in air by introducing the well-optimized photonic sintering at a time frame of 10−3 s, at which the photon energy, rather than conventional thermal energy, is instantly provided. It is elucidated here how the surface oxide-free, printed Cu particulate films undergo chemical structural/microstructural evolution depending on the instantly irradiated photon energy, and a successful demonstration is provided of large-area, flexible, printed Cu conductors on various substrates, including polyimide (PI), polyethersulfone (PES), polyethylene terephthalate (PET), and paper. The applicability of the resulting printed Cu electrodes is evaluated via implementation into both flexible capacitor devices and indium–gallium–zinc oxide (IGZO) flexible thin-film transistors.
 A1  - Oh, Sang-Jin
 A1  - Jo, Yejin
@@ -1172,7 +1172,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2055-6756
 DO  - 10.1039/C7NH00137A
 M3  - 10.1039/C7NH00137A
-UR  - http://dx.doi.org/10.1039/C7NH00137A
+UR  - https://doi.org/10.1039/C7NH00137A
 N2  - Group 6 transition metal dichalcogenides (G6-TMDs), most notably MoS2, MoSe2, MoTe2, WS2 and WSe2, constitute an important class of materials with a layered crystal structure. Various types of G6-TMD nanomaterials, such as nanosheets, nanotubes and quantum dot nano-objects and flower-like nanostructures, have been synthesized. High thermodynamic stability under ambient conditions, even in atomically thin form, made nanosheets of these inorganic semiconductors a valuable asset in the existing library of two-dimensional (2D) materials, along with the well-known semimetallic graphene and insulating hexagonal boron nitride. G6-TMDs generally possess an appropriate bandgap (1–2 eV) which is tunable by size and dimensionality and changes from indirect to direct in monolayer nanosheets, intriguing for (opto)electronic, sensing, and solar energy harvesting applications. Moreover, rich intercalation chemistry and abundance of catalytically active edge sites make them promising for fabrication of novel energy storage devices and advanced catalysts. In this review, we provide an overview on all aspects of the basic science, physicochemical properties and characterization techniques as well as all existing production methods and applications of G6-TMD nanomaterials in a comprehensive yet concise treatment. Particular emphasis is placed on establishing a linkage between the features of production methods and the specific needs of rapidly growing applications of G6-TMDs to develop a production-application selection guide. Based on this selection guide, a framework is suggested for future research on how to bridge existing knowledge gaps and improve current production methods towards technological application of G6-TMD nanomaterials.
 A1  - Samadi, Morasae
 A1  - Sarikhani, Navid
@@ -1196,7 +1196,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C8CS00237A
 M3  - 10.1039/C8CS00237A
-UR  - http://dx.doi.org/10.1039/C8CS00237A
+UR  - https://doi.org/10.1039/C8CS00237A
 N2  - Compatible energy storage devices that are able to withstand various mechanical deformations, while delivering their intended functions, are required in wearable technologies. This imposes constraints on the structural designs, materials selection, and miniaturization of the cells. To date, extensive efforts have been dedicated towards developing electrochemical energy storage devices for wearables, with a focus on incorporation of shape-conformable materials into mechanically robust designs that can be worn on the human body. In this review, we highlight the quantified performances of reported wearable electrochemical energy storage devices, as well as their micro-sized counterparts under specific mechanical deformations, which can be used as the benchmark for future studies in this field. A general introduction to the wearable technology, the development of the selection and synthesis of active materials, cell design approaches and device fabrications are discussed. It is followed by challenges and outlook toward the practical use of electrochemical energy storage devices for wearable applications.
 A1  - Sumboja, Afriyanti
 A1  - Liu, Jiawei
@@ -1220,7 +1220,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C3TC32197E
 M3  - 10.1039/C3TC32197E
-UR  - http://dx.doi.org/10.1039/C3TC32197E
+UR  - https://doi.org/10.1039/C3TC32197E
 N2  - Flexible photovoltaic (PV) devices have attracted enormous attention from academy and industry as a convenient alternative energy source for indoor and outdoor applications. Flexible PV panels can be easily integrated with infrastructures of various shapes and sizes, meanwhile they are light-weight and thus suitable for applications where weight is important. In this review, we will describe the progress that has been made in the field of flexible PV technologies. In addition, a summary will be provided with perspective on the future development of flexible solar cells and new opportunities offered by these devices.
 A1  - Lin, Qingfeng
 A1  - Huang, Hongtao
@@ -1246,7 +1246,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C4NR03915G
 M3  - 10.1039/C4NR03915G
-UR  - http://dx.doi.org/10.1039/C4NR03915G
+UR  - https://doi.org/10.1039/C4NR03915G
 N2  - In this review, we survey several recent developments in printing of nanomaterials for contacts, transistors, sensors of various kinds, light-emitting diodes, solar cells, memory devices, and bone and organ implants. The commonly used nanomaterials are classified according to whether they are conductive, semiconducting/insulating or biological in nature. While many printing processes are covered, special attention is paid to inkjet printing and roll-to-roll printing in light of their complexity and popularity. In conclusion, we present our view of the future development of this field.
 A1  - Choi, Hyung Woo
 A1  - Zhou, Tianlei
@@ -1268,7 +1268,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1359-7345
 DO  - 10.1039/C3CC46224B
 M3  - 10.1039/C3CC46224B
-UR  - http://dx.doi.org/10.1039/C3CC46224B
+UR  - https://doi.org/10.1039/C3CC46224B
 N2  - A step towards commercialization of dye-sensitized solar cells (DSSCs) requires more attention to engineering aspects, such as flexibility, the roll to roll fabrication process, the use of cost effective materials, etc. In this aspect, advantages of flexible DSSCs attracted many researchers to contemplate the transparent conducting oxide coated flexible plastic substrates and the thin metallic foils. In this feature article, the pros and cons of these two kinds of substrates are compared. The flexible dye-sensitized solar cells fabricated using metal substrates are briefly discussed. The working electrodes of DSSCs fabricated on various metal substrates, their fabrication methods, the effect of high temperature calcination and drawbacks of back illumination are reviewed in detail. A few reports on the flexible metal substrate based counter electrodes that could be combined with the plastic substrate based working electrodes are also covered at the end.
 A1  - Balasingam, Suresh Kannan
 A1  - Kang, Man Gu
@@ -1289,7 +1289,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C6TA05441B
 M3  - 10.1039/C6TA05441B
-UR  - http://dx.doi.org/10.1039/C6TA05441B
+UR  - https://doi.org/10.1039/C6TA05441B
 N2  - Inspired by the self-cleaning and water-repellent properties of plants and animals in the natural world, superhydrophobic and superoleophobic materials develop quickly, and are of great interest in academic and industrial areas. Although various chemicals have been used, silanes and silicones play very important roles in the preparation of superhydrophobic and superoleophobic materials. Approximately 25% of the literature about superhydrophobic and superoleophobic materials is based on silanes and silicones. Thus, we believe that an exhaustive literature review from the viewpoint of silane and silicone chemistry is now pertinent to give an overview of the recent progress about their roles in the preparation of superhydrophobic and superoleophobic materials. First of all, we hope to overview the roles of silanes and silicones in constructing micro-/nanostructures, decreasing the surface energy and/or as binders for the fabrication of superhydrophobic and superoleophobic surfaces. We will then focus on the roles of silanes and silicones in the formation of superhydrophobic and superoleophobic particles, sponges and aerogels. In the conclusions, we will summarize the roles of silanes and silicones in forming superhydrophobic and superoleophobic materials, and the challenges in the field. Overall, this review will hopefully help readers to use silanes and silicones dexterously in the design of novel superhydrophobic and superoleophobic materials.
 A1  - Li, Lingxiao
 A1  - Li, Bucheng
@@ -1311,7 +1311,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C7TC02965A
 M3  - 10.1039/C7TC02965A
-UR  - http://dx.doi.org/10.1039/C7TC02965A
+UR  - https://doi.org/10.1039/C7TC02965A
 N2  - During the past few decades, CNT/Cu based composite materials have fascinated the worldwide research community with their phenomenal mechanical and thermal properties. In addition, CNT/Cu composites have shown remarkable electrical properties and have become a booming candidate in the present electrical, semiconductor and packaging industries. Though several research groups have developed CNT/Cu composites with high conductive properties, very few could even come closer to the benchmark conductivity of pure Cu conductors. The conductivity of the composite has shown dependency on several key factors, including CNT alignment, CNT dispersion and material interface, which can be shaped during its fabrication procedures. Each of these factors has shown a significant interdependency and effective tailoring of those factors can result in better composites with enhanced electrical properties while retaining its mechanical robustness. High flexibility and the improved fatigue life have opened the pathways for CNT/Cu composites into flexible/wearable electronics where CNT/Cu has been introduced into energy storage, energy conversion and sensing systems. In this review article, different approaches on achieving enhanced conductive properties will be presented based on the respective factors they have dealt with. On top of the main discussion on composite electrical conductivity, an overview on CNT/Cu composite applications in flexible/wearable electronics will be presented. The discussion on wearable/flexible electronics will be based on their materials, methods and principal functionalities.
 A1  - Jayathilaka, W. A. D. M.
 A1  - Chinnappan, Amutha
@@ -1332,7 +1332,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1473-0197
 DO  - 10.1039/C6LC00737F
 M3  - 10.1039/C6LC00737F
-UR  - http://dx.doi.org/10.1039/C6LC00737F
+UR  - https://doi.org/10.1039/C6LC00737F
 N2  - This review shows the recent advances and state of the art in paper-based analytical devices (PADs) through the analysis of their integration with microfluidics and LOC micro- and nanotechnologies, electrochemical/optical detection and electronic devices as the convergence of various knowledge areas. The important role of the paper design/architecture in the improvement of the performance of sensor devices is discussed. The discussion is fundamentally based on μPADs as the new generation of paper-based (bio)sensors. Data about the scientific publication ranking of PADs, illustrating their increase as an experimental research topic in the past years, are supplied. In addition, an analysis of the simultaneous evolution of PADs in academic lab research and industrial commercialization highlighting the parallelism of the technological transfer from academia to industry is displayed. A general overview of the market behaviour, the leading industries in the sector and their commercialized devices is given. Finally, personal opinions of the authors about future perspectives and tendencies in the design and fabrication technology of PADs are disclosed.
 A1  - López-Marzo, Adaris M.
 A1  - Merkoçi, Arben
@@ -1352,7 +1352,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C0CS00147C
 M3  - 10.1039/C0CS00147C
-UR  - http://dx.doi.org/10.1039/C0CS00147C
+UR  - https://doi.org/10.1039/C0CS00147C
 N2  - The applications and potentials of thin film coatings of metal–organic frameworks (MOFs) supported on various substrates are discussed in this critical review. Because the demand for fabricating such porous coatings is rather obvious, in the past years several synthesis schemes have been developed for the preparation of thin porous MOF films. Interestingly, although this is an emerging field seeing a rapid development a number of different applications on MOF films were either already demonstrated or have been proposed. This review focuses on the fabrication of continuous, thin porous films, either supported on solid substrates or as free-standing membranes. The availability of such two-dimensional types of porous coatings opened the door for a number of new perspectives for functionalizing surfaces. Also for the porous materials themselves, the availability of a solid support to which the MOF-films are rigidly (in a mechanical sense) anchored provides access to applications not available for the typical MOF powders with particle sizes of a few μm. We will also address some of the potential and applications of thin films in different fields like luminescence, QCM-based sensors, optoelectronics, gas separation and catalysis. A separate chapter has been devoted to the delamination of MOF thin films and discusses the potential to use them as free-standing membranes or as nano-containers. The review also demonstrates the possibility of using MOF thin films as model systems for detailed studies on MOF-related phenomena, e.g. adsorption and diffusion of small molecules into MOFs as well as the formation mechanism of MOFs (101 references).
 A1  - Shekhah, O.
 A1  - Liu, J.
@@ -1374,7 +1374,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1754-5692
 DO  - 10.1039/C6EE03526D
 M3  - 10.1039/C6EE03526D
-UR  - http://dx.doi.org/10.1039/C6EE03526D
+UR  - https://doi.org/10.1039/C6EE03526D
 N2  - Three dimensional printing technologies represent a revolution in the manufacturing sector because of their unique capabilities for increasing shape complexity while reducing waste material, capital cost and design for manufacturing. However, the application of 3D printing technologies for the fabrication of functional components or devices is still an almost unexplored field due to their elevated complexity from the materials and functional points of view. This paper focuses on reviewing previous studies devoted to developing 3D printing technologies for the fabrication of functional parts and devices for energy and environmental applications. The use of 3D printing technologies in these sectors is of special interest since the related devices usually involve expensive advanced materials such as ceramics or composites, which present strong limitations in shape and functionality when processed with classical manufacturing methods. Recent advances regarding the implementation of 3D printing for energy and environmental applications will bring competitive advantages in terms of performance, product flexibility and cost, which will drive a revolution in this sector.
 A1  - Ruiz-Morales, J. C.
 A1  - Tarancón, A.
@@ -1400,7 +1400,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C7CS00139H
 M3  - 10.1039/C7CS00139H
-UR  - http://dx.doi.org/10.1039/C7CS00139H
+UR  - https://doi.org/10.1039/C7CS00139H
 N2  - Flexible energy storage systems are imperative for emerging flexible devices that are revolutionizing our life. Lithium-ion batteries, the current main power sources, are gradually approaching their theoretical limitation in terms of energy density. Therefore, alternative battery chemistries are urgently required for next-generation flexible power sources with high energy densities, low cost, and inherent safety. Flexible lithium–sulfur (Li–S) batteries and analogous flexible alkali metal–chalcogen batteries are of paramount interest owing to their high energy densities endowed by multielectron chemistry. In this review, we summarized the recent progress of flexible Li–S and analogous batteries. A brief introduction to flexible energy storage systems and general Li–S batteries has been provided first. Progress in flexible materials for flexible Li–S batteries are reviewed subsequently, with a detailed classification of flexible sulfur cathodes as those based on carbonaceous (e.g., carbon nanotubes, graphene, and carbonized polymers) and composite (polymers and inorganics) materials and an overview of flexible lithium anodes and flexible solid-state electrolytes. Advancements in other flexible alkali metal–chalcogen batteries are then introduced. In the next part, we emphasize the importance of cell packaging and flexibility evaluation, and two special flexible battery prototypes of foldable and cable-type Li–S batteries are highlighted. In the end, existing challenges and future development of flexible Li–S and analogous alkali metal–chalcogen batteries are summarized and prospected.
 A1  - Peng, Hong-Jie
 A1  - Huang, Jia-Qi
@@ -1421,7 +1421,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C7TC00202E
 M3  - 10.1039/C7TC00202E
-UR  - http://dx.doi.org/10.1039/C7TC00202E
+UR  - https://doi.org/10.1039/C7TC00202E
 N2  - In the field of solid-state lighting (SSL) technologies, light-emitting electrochemical cells (LECs) are the leading example of easy-to-fabricate and simple-architecture devices. The key-aspect of this technology is the use of a single active layer that consists of a mixture of an emitter and an ionic polyelectrolyte. The presence of mobile anions efficiently assists both charge injection and charge transport processes using air-stable electrodes. This concept reported in the mid-90s was considered as a game-changer approach, leading to a new field in SSL. Since then, the evolution of the LEC technology has involved different stages, namely (i) the search for the best combination of emitters (luminescent conjugated polymers and ionic transition complexes) and additives (ionic polyelectrolytes, ionic liquids, and neutral polymers), (ii) the understanding of the device mechanism using several techniques like electrostatic force microscopy (EFM), microcavity effects, scanning Kelvin probe microscopy (SKPM), time-of-flight secondary ion mass spectroscopy (ToF-SIMS), electrochemical impedance spectroscopy (EIS), etc., (iii) the development of simple and up-scalable device fabrication processes and, recently, (iv) the quest for new emitters like copper(I) complexes, small-molecules, quantum dots, and perovskites. This review provides a general overview of the first three points and, in particular, an in-depth revision of the recent advances in designing new architectures and emitters for LECs.
 A1  - Fresta, Elisa
 A1  - Costa, Rubén D.
@@ -1441,7 +1441,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C0CS00136H
 M3  - 10.1039/C0CS00136H
-UR  - http://dx.doi.org/10.1039/C0CS00136H
+UR  - https://doi.org/10.1039/C0CS00136H
 N2  - Today cross-cutting approaches, where molecular engineering and clever processing are synergistically coupled, allow the chemist to tailor complex hybrid systems of various shapes with perfect mastery at different size scales, composition, functionality, and morphology. Hybrid materials with organic–inorganic or bio–inorganic character represent not only a new field of basic research but also, via their remarkable new properties and multifunctional nature, hybrids offer prospects for many new applications in extremely diverse fields. The description and discussion of the major applications of hybrid inorganic–organic (or biologic) materials are the major topic of this critical review. Indeed, today the very large set of accessible hybrid materials span a wide spectrum of properties which yield the emergence of innovative industrial applications in various domains such as optics, micro-electronics, transportation, health, energy, housing, and the environment among others (526 references).
 A1  - Sanchez, Clément
 A1  - Belleville, Philippe
@@ -1463,7 +1463,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C8CS00317C
 M3  - 10.1039/C8CS00317C
-UR  - http://dx.doi.org/10.1039/C8CS00317C
+UR  - https://doi.org/10.1039/C8CS00317C
 N2  - This article is an overview of the present and ongoing developments in the field of nanomaterial-based sensors for enabling fast, relatively inexpensive and minimally (or non-) invasive diagnostics of health conditions with follow-up by detecting volatile organic compounds (VOCs) excreted from one or combination of human body fluids and tissues (e.g., blood, urine, breath, skin). Part of the review provides a didactic examination of the concepts and approaches related to emerging sensing materials and transduction techniques linked with the VOC-based non-invasive medical evaluations. We also present and discuss diverse characteristics of these innovative sensors, such as their mode of operation, sensitivity, selectivity and response time, as well as the major approaches proposed for enhancing their ability as hybrid sensors to afford multidimensional sensing and information-based sensing. The other parts of the review give an updated compilation of the past and currently available VOC-based sensors for disease diagnostics. This compilation summarizes all VOCs identified in relation to sickness and sampling origin that links these data with advanced nanomaterial-based sensing technologies. Both strength and pitfalls are discussed and criticized, particularly from the perspective of the information and communication era. Further ideas regarding improvement of sensors, sensor arrays, sensing devices and the proposed workflow are also included.
 A1  - Broza, Yoav Y.
 A1  - Vishinkin, Rotem
@@ -1486,7 +1486,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1754-5692
 DO  - 10.1039/C3EE43182G
 M3  - 10.1039/C3EE43182G
-UR  - http://dx.doi.org/10.1039/C3EE43182G
+UR  - https://doi.org/10.1039/C3EE43182G
 N2  - With the advent of flexible electronics, flexible lithium-ion batteries have attracted great attention as a promising power source in the emerging field of flexible and wearable electronic devices such as roll-up displays, touch screens, conformable active radio-frequency identification tags, wearable sensors and implantable medical devices. In this review, we summarize the recent research progress of flexible lithium-ion batteries, with special emphasis on electrode material selectivity and battery structural design. We begin with a brief introduction of flexible lithium-ion batteries and the current development of flexible solid-state electrolytes for applications in this field. This is followed by a detailed overview of the recent progress on flexible electrode materials based on carbon nanotubes, graphene, carbon cloth, conductive paper (cellulose), textiles and some other low-dimensional nanostructured materials. Then recently proposed prototypes of flexible cable/wire type, transparent and stretchable lithium-ion batteries are highlighted. The latest advances in the exploration of other flexible battery systems such as lithium–sulfur, Zn–C (MnO2) and sodium-ion batteries, as well as related electrode materials are included. Finally, the prospects and challenges toward the practical uses of flexible lithium-ion batteries in electronic devices are discussed.
 A1  - Zhou, Guangmin
 A1  - Li, Feng
@@ -1507,7 +1507,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C5TA10582J
 M3  - 10.1039/C5TA10582J
-UR  - http://dx.doi.org/10.1039/C5TA10582J
+UR  - https://doi.org/10.1039/C5TA10582J
 N2  - Supercapacitors are important energy storage devices capable of delivering energy at a very fast rate. With the increasing interest in portable and wearable electronic equipment, various flexible supercapacitors (FSCs) and flexible electrodes (FEs) have been investigated widely and constantly in recent years. Currently-developed FEs/FSCs exhibit myriad physical forms and functional features and form a complicated and extensive system. Herein, we summarize the recent results about FEs/FSCs and present this review by categories. According to different micro-structures and macroscopic patterns, the existing FEs/FSCs can be divided into three types: fiber-like FEs/FSCs; paper-like FEs/FSCs; and three-dimensional porous FEs (and corresponding FSCs). Subsequently each type of the FEs/FSCs is further sub-classified based on their construction rules, and mechanical and electrochemical properties. To our best knowledge, this is the first time such a hierarchical and detailed classification strategy has been propose. We believe it will be beneficial for researchers around the world to understand FEs/FSCs. In addition, we bring up some fresh ideas for the future development of wearable energy storage devices.
 A1  - Dong, Liubing
 A1  - Xu, Chengjun
@@ -1532,7 +1532,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C6CS00218H
 M3  - 10.1039/C6CS00218H
-UR  - http://dx.doi.org/10.1039/C6CS00218H
+UR  - https://doi.org/10.1039/C6CS00218H
 N2  - If two-dimensional (2D) nanomaterials are ever to be utilized as components of practical, macroscopic devices on a large scale, there is a complementary need to controllably assemble these 2D building blocks into more sophisticated and hierarchical three-dimensional (3D) architectures. Such a capability is key to design and build complex, functional devices with tailored properties. This review provides a comprehensive overview of the various experimental strategies currently used to fabricate the 3D macro-structures of 2D nanomaterials. Additionally, various approaches for the decoration of the 3D macro-structures with organic molecules, polymers, and inorganic materials are reviewed. Finally, we discuss the applications of 3D macro-structures, especially in the areas of energy, environment, sensing, and electronics, and describe the existing challenges and the outlook for this fast emerging field.
 A1  - Shehzad, Khurram
 A1  - Xu, Yang
@@ -1554,7 +1554,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1754-5692
 DO  - 10.1039/C4EE03685A
 M3  - 10.1039/C4EE03685A
-UR  - http://dx.doi.org/10.1039/C4EE03685A
+UR  - https://doi.org/10.1039/C4EE03685A
 N2  - Graphene is a unique and attractive energy material because of its atom-thick two-dimensional structure and excellent properties. Graphene sheets are also mechanically strong and flexible. Thus, graphene materials are expected to have wide and practical applications in bendable, foldable and/or stretchable devices related to energy conversion and storage. We present a review on the recent advancements in flexible graphene energy devices including photovoltaic devices, fuel cells, nanogenerators (NGs), supercapacitors (SCs) and batteries, and the devices related to energy conversion such as organic light-emitting diodes (OLEDs), photodetectors and actuators. The strategies for synthesizing flexible graphene materials will be summarized and the challenges facing the design and construction of the devices will be discussed.
 A1  - Wang, Xiluan
 A1  - Shi, Gaoquan
@@ -1574,7 +1574,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-750X
 DO  - 10.1039/C6TB02009G
 M3  - 10.1039/C6TB02009G
-UR  - http://dx.doi.org/10.1039/C6TB02009G
+UR  - https://doi.org/10.1039/C6TB02009G
 N2  - With the increased use of nanobiotechnology-enabled solutions for diagnostics, therapeutics, bioelectronics, environmental, and energy-related applications, there exists a great demand for developing manufacturing processes that can reliably and reproducibly generate functional nanostructures with bioactive properties at low cost and in large quantities for implementation in practical devices. Interest in the development of field portable monitoring devices has increased throughout the past decade. Herein we describe fabrication, characterization and performance of portable and printable enzyme biosensors based on functional enzyme–nanoparticle conjugates. We review specific physicochemical and surface properties of nanoparticles used as carriers and sensing components for the design of portable biosensors and describe the role of these parameters in enhancing the performance, stability and field operability of these devices. Assembly of enzyme–nanoparticle conjugates is also discussed with an overview of current and emerging techniques enabling large scale roll-to-roll fabrication and miniaturization, including screen-printing, inkjet and 3D printing methods and their integration in flexible, wearable and inexpensive point-of-use devices. Current status and implementation challenges are provided with examples of applications in the clinical, environmental, public safety and food monitoring fields.
 A1  - Othman, Ali
 A1  - Karimi, Anahita
@@ -1595,7 +1595,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C5TC03679H
 M3  - 10.1039/C5TC03679H
-UR  - http://dx.doi.org/10.1039/C5TC03679H
+UR  - https://doi.org/10.1039/C5TC03679H
 N2  - There is an increasing interest in the area of conductive textiles, also called e-textiles, in both the scientific and industrial fields. Herein, we have successfully prepared a conductive textile via electroless deposition onto cotton textiles by using a three-step treatment process. The cotton textiles are first dipped in P4VP–SU8 solution to form a uniform layer for the subsequent absorption of silver ions. Then, the cotton textiles are immersed in silver nitrate solution in preparation for the next step electroless deposition. The parameters like P4VP concentration and ELD conditions are studied to optimize the whole process. Compared to other methods, the whole fabrication process is efficient, facile and time-saving. The as-made cotton fabric sample showed sheet resistance as low as 0.05 Ω sq−1, which makes this method a promising candidate for applications in the fabrication of functional textile-based wearable devices.
 A1  - Liu, Sicong
 A1  - Hu, Mingjun
@@ -1616,7 +1616,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1754-5692
 DO  - 10.1039/C3EE43024C
 M3  - 10.1039/C3EE43024C
-UR  - http://dx.doi.org/10.1039/C3EE43024C
+UR  - https://doi.org/10.1039/C3EE43024C
 N2  - Although paper electronics is a compelling concept, the large surface roughness and opaqueness of most paper substrates has hindered its development from a dormant idea to a thriving technology. A recent demonstration of transparent paper with nanoscale surface roughness has revived an interest in using renewable cellulose substrates for electronics and optoelectronics. In this short review, we will first summarize the recent progress of transparent paper electronics through structure engineering. We will also discuss the properties and functionalization of transparent paper, such as surface roughness, printability, thermal stability, etc. Finally, we will summarize the recent achievements on proof-of-concepts of transparent paper, which pave the way for next-generation green electronics fabricated with roll-to-roll printing methods. Advantages of transparent paper over traditional flexible plastic substrates and its challenges will also be discussed.
 A1  - Zhu, Hongli
 A1  - Fang, Zhiqiang
@@ -1639,7 +1639,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C5CS00174A
 M3  - 10.1039/C5CS00174A
-UR  - http://dx.doi.org/10.1039/C5CS00174A
+UR  - https://doi.org/10.1039/C5CS00174A
 N2  - Paper-based supercapacitors (SCs), a novel and interesting group of flexible energy storage devices, are attracting more and more attention from both industry and academia. Cellulose papers with a unique porous bulk structure and rough and absorptive surface properties enable the construction of paper-based SCs with a reasonably good performance at a low price. The inexpensive and environmentally friendly nature of paper as well as simple fabrication techniques make paper-based SCs promising candidates for the future ‘green’ and ‘once-use-and-throw-away’ electronics. This review introduces the design, fabrication and applications of paper-based SCs, giving a comprehensive coverage of this interesting field. Challenges and future perspectives are also discussed.
 A1  - Zhang, Yi-Zhou
 A1  - Wang, Yang
@@ -1663,7 +1663,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C4NR00102H
 M3  - 10.1039/C4NR00102H
-UR  - http://dx.doi.org/10.1039/C4NR00102H
+UR  - https://doi.org/10.1039/C4NR00102H
 N2  - This is a review on recent developments in the field of transparent conductive coatings (TCCs) for ITO replacement. The review describes the basic properties of conductive nanomaterials suitable for fabrication of such TCCs (metallic nanoparticles and nanowires, carbon nanotubes and graphene sheets), various methods of patterning the metal nanoparticles with formation of conductive transparent metallic grids, honeycomb structures and 2D arrays of interconnected rings as well as fabrication of TCCs based on graphene and carbon nanotubes. Applications of TCCs in electronic and optoelectronic devices, such as solar cells, electroluminescent and electrochromic devices, touch screens and displays, and transparent EMI shielders, are discussed.
 A1  - Layani, Michael
 A1  - Kamyshny, Alexander
@@ -1684,7 +1684,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C7TA04577H
 M3  - 10.1039/C7TA04577H
-UR  - http://dx.doi.org/10.1039/C7TA04577H
+UR  - https://doi.org/10.1039/C7TA04577H
 N2  - Owing to their structural advantages in comparison with bulk polydimethylsiloxane (PDMS), porous 3D substrates, which are also known as PDMS sponges, possess immense potential in energy generation, transport and storage, absorption, separation, photocatalysis, wearable electronics and life science applications. Extensive effort has therefore been devoted to the design and synthesis of porous PDMS sponges. The key to excellent performance in high-value applications is a deep knowledge of the beneficial aspects of their porosity, structure and morphology for a specific application. Several new routes for the fabrication of PDMS sponges, as well as novel applications, have been developed recently. Therefore, this review focuses on advances in the field of the fabrication and application of PDMS sponges since 2011. After a concise introduction, which includes remarks on the benefits of PDMS in comparison with other materials, strategies for the synthesis/fabrication of PDMS sponges are presented and their advantages and drawbacks are concisely discussed. A summary of the potential fabrication procedures will be beneficial for those entering the field, as it gives a quick overview of the feasible applications of a PDMS sponge fabricated via a specific method. Afterwards, different high-value applications of PDMS sponges are described in conjunction with specific and detailed examples of all the abovementioned applications. In this regard, suggestions are also made regarding which fabrication method is most beneficial for the application being discussed. Finally, recent advances in the fabrication and application of PDMS sponges are summarized, as well as issues, such as surface functionalization and pore size limitations, which are impeding reasonable future applications. We envision that this review will be helpful to those entering the field, as well as experienced researchers who need rapid access to recent literature, and will give new stimuli for the development of novel porous materials.
 A1  - Zhu, Deyong
 A1  - Handschuh-Wang, Stephan
@@ -1705,7 +1705,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1463-9262
 DO  - 10.1039/C4GC02195A
 M3  - 10.1039/C4GC02195A
-UR  - http://dx.doi.org/10.1039/C4GC02195A
+UR  - https://doi.org/10.1039/C4GC02195A
 N2  - Recently, the first commercially successful applications for organic light-emitting devices (OLEDs) have entered the lighting and display markets, especially in smaller devices such as tablets and smartphones. In this article, we analyse materials and techniques used in OLED manufacturing in terms of sustainability and highlight upcoming trends which are supposed to further enhance this technologies sustainability.
 A1  - Volz, D.
 A1  - Wallesch, M.
@@ -1732,7 +1732,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1473-0197
 DO  - 10.1039/C7LC00121E
 M3  - 10.1039/C7LC00121E
-UR  - http://dx.doi.org/10.1039/C7LC00121E
+UR  - https://doi.org/10.1039/C7LC00121E
 N2  - Commercialization of lab-on-a-chip devices is currently the “holy grail” within the μTAS research community. While a wide variety of highly sophisticated chips which could potentially revolutionize healthcare, biology, chemistry and all related disciplines are increasingly being demonstrated, very few chips are or can be adopted by the market and reach the end-users. The major inhibition factor lies in the lack of an established commercial manufacturing technology. The lab-on-printed circuit board (lab-on-PCB) approach, while suggested many years ago, only recently has re-emerged as a very strong candidate, owing to its inherent upscaling potential: the PCB industry is well established all around the world, with standardized fabrication facilities and processes, but commercially exploited currently only for electronics. Owing to these characteristics, complex μTASs integrating microfluidics, sensors, and electronics on the same PCB platform can easily be upscaled, provided more processes and prototypes adapted to the PCB industry are proposed. In this article, we will be reviewing for the first time the PCB-based prototypes presented in the literature to date, highlighting the upscaling potential of this technology. The authors believe that further evolution of this technology has the potential to become a much sought-after standardized industrial fabrication technology for low-cost μTASs, which could in turn trigger the projected exponential market growth of μTASs, in a fashion analogous to the revolution of Si microchips via the CMOS industry establishment.
 A1  - Moschou, Despina
 A1  - Tserepi, Angeliki
@@ -1752,7 +1752,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C6TC01066K
 M3  - 10.1039/C6TC01066K
-UR  - http://dx.doi.org/10.1039/C6TC01066K
+UR  - https://doi.org/10.1039/C6TC01066K
 N2  - A facile, environmentally-friendly, low-cost, and scalable deposition process has been developed and automated to apply polyelectrolyte multilayers (PEMs) on flexible Kapton HN substrates. Two weak polyelectrolytes, poly(acrylic acid) and polyethylenimine, were deposited in an alternating, layer-by-layer fashion under controlled pH and ionic strength. Compared to strong polyelectrolytes, weak electrolytes can control the properties of the PEMs more systmatically and simply. To our knowledge, this work on surface modification of Kapton is not only the first to use only weak polyelectrolytes, but is also the first to take advantage of the surface properties of calcium-bearing additive particles present in Kapton HN. The resulting surface-modified Kapton HN substrate allowed for the inkjet printing of water-based graphene oxide (GO) inks and organic solvent-based inks with good adhesion and with desired printability. While the deposition of a single PEM layer on a Kapton substrate significantly reduced the water contact angle and allowed for the inkjet-printing of GO inks, the deposition of additional PEM layers was required to maintain the adhesion during post-printing chemical treatments. As a conceptual demonstration of the general applicability of this PEM surface modification approach, a flexible, robust, single-layered gas sensor prototype was fully inkjet printed with both water- and ethanol-based inks and tested for its sensitivity to diethyl ethylphosphonate (DEEP), a simulant for G-series nerve agents. The electrical conductivity and morphology of the sensor were found to be insensitive to repeated bending around a 1 cm radius.
 A1  - Fang, Yunnan
 A1  - Hester, Jimmy G. D.
@@ -1779,7 +1779,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C4NR02041C
 M3  - 10.1039/C4NR02041C
-UR  - http://dx.doi.org/10.1039/C4NR02041C
+UR  - https://doi.org/10.1039/C4NR02041C
 N2  - Three-dimensional (3D) printing is a fabrication method that enables creation of structures from digital models. Among the different structures fabricated by 3D printing methods, helical microstructures attracted the attention of the researchers due to their potential in different fields such as MEMS, lab-on-a-chip systems, microelectronics and telecommunications. Here we review different types of 3D printing methods capable of fabricating 3D freeform helical microstructures. The techniques including two more common microfabrication methods (i.e., focused ion beam chemical vapour deposition and microstereolithography) and also five methods based on computer-controlled robotic direct deposition of ink filament (i.e., fused deposition modeling, meniscus-confined electrodeposition, conformal printing on a rotating mandrel, UV-assisted and solvent-cast 3D printings) and their advantages and disadvantages regarding their utilization for the fabrication of helical microstructures are discussed. Focused ion beam chemical vapour deposition and microstereolithography techniques enable the fabrication of very precise shapes with a resolution down to ∼100 nm. However, these techniques may have material constraints (e.g., low viscosity) and/or may need special process conditions (e.g., vacuum chamber) and expensive equipment. The five other techniques based on robotic extrusion of materials through a nozzle are relatively cost-effective, however show lower resolution and less precise features. The popular fused deposition modeling method offers a wide variety of printable materials but the helical microstructures manufactured featured a less precise geometry compared to the other printing methods discussed in this review. The UV-assisted and the solvent-cast 3D printing methods both demonstrated high performance for the printing of 3D freeform structures such as the helix shape. However, the compatible materials used in these methods were limited to UV-curable polymers and polylactic acid (PLA), respectively. Meniscus-confined electrodeposition is a flexible, low cost technique that is capable of fabricating 3D structures both in nano- and microscales including freeform helical microstructures (down to few microns) under room conditions using metals. However, the metals suitable for this technique are limited to those that can be electrochemically deposited with the use of an electrolyte solution. The highest precision on the helix geometry was achieved using the conformal printing on a rotating mandrel. This method offers the lowest shape deformation after printing but requires more tools (e.g., mandrel, motor) and the printed structure must be separated from the mandrel. Helical microstructures made of multifunctional materials (e.g., carbon nanotube nanocomposites, metallic coated polymer template) were used in different technological applications such as strain/load sensors, cell separators and micro-antennas. These innovative 3D microsystems exploiting the unique helix shape demonstrated their potential for better performance and more compact microsystems.
 A1  - Farahani, R. D.
 A1  - Chizari, K.
@@ -1800,7 +1800,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C8CS00706C
 M3  - 10.1039/C8CS00706C
-UR  - http://dx.doi.org/10.1039/C8CS00706C
+UR  - https://doi.org/10.1039/C8CS00706C
 N2  - Highly conductive and intrinsically stretchable electrodes are vital components of soft electronics such as stretchable transistors and circuits, sensors and actuators, light-emitting diode arrays, and energy harvesting devices. Many kinds of conducting nanomaterials with outstanding electrical and mechanical properties have been integrated with elastomers to produce stretchable conductive nanocomposites. Understanding the characteristics of these nanocomposites and assessing the feasibility of their fabrication are therefore critical for the development of high-performance stretchable conductors and electronic devices. We herein summarise the recent advances in stretchable conductors based on the percolation networks of nanoscale conductive fillers in elastomeric media. After discussing the material-, dimension-, and size-dependent properties of conductive fillers and their implications, we highlight various techniques that are used to reduce the contact resistance between the conductive filler materials. Furthermore, we categorize elastomer matrices with different stretchabilities and mechanical properties based on their polymeric chain structures. Then, we discuss the fabrication techniques of stretchable conductive nanocomposites toward their use in soft electronics. Finally, we provide representative examples of stretchable device applications and conclude the review with a brief outlook for future research.
 A1  - Choi, Suji
 A1  - Han, Sang Ihn
@@ -1823,7 +1823,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C7NR04656A
 M3  - 10.1039/C7NR04656A
-UR  - http://dx.doi.org/10.1039/C7NR04656A
+UR  - https://doi.org/10.1039/C7NR04656A
 N2  - Traditional paper and papermaking have struggled with a declining market during the last few decades. However, the incorporation of nanotechnology into papermaking has brought possibilities to develop low-cost, biocompatible and flexible products with sophisticated functionalities. The functionality of nanopapers emerges from the intrinsic properties of the nanofibrous network, the additional loading of specific nanomaterials (NMs), or the additional deposition and patterning of thin films of nanomaterials on the paper surface. A successful development of functional nanopapers requires understanding how the nanopaper matrix, nanofillers, nanocoating pigments, nanoprinting inks, processing additives and manufacturing processes all interact to provide the intended functionality. This review addresses the emerging area of functional nanopapers. This review discusses flexible and multifunctional nanopapers, NMs being used in nanopaper making, manufacturing techniques, and functional applications that provide new important possibilities to utilize papermaking technology. The interface where NM research meets traditional papermaking has important implications for food packaging, energy harvesting and energy storage, flexible electronics, low-cost devices for medical diagnostics, and numerous other areas.
 A1  - Barhoum, Ahmed
 A1  - Samyn, Pieter
@@ -1845,7 +1845,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C4TA02071E
 M3  - 10.1039/C4TA02071E
-UR  - http://dx.doi.org/10.1039/C4TA02071E
+UR  - https://doi.org/10.1039/C4TA02071E
 N2  - This review gives an overview of recent advances in the potential applications of superhydrophobic materials. Such properties are characterized by extremely high water contact angles and various adhesion properties. The conception of superhydrophobic materials has been possible by studying and mimicking natural surfaces. Now, various applications have emerged such as anti-icing, anti-corrosion and anti-bacterial coatings, microfluidic devices, textiles, oil–water separation, water desalination/purification, optical devices, sensors, batteries and catalysts. At least two parameters were found to be very important for many applications: the presence of air on superhydrophobic materials with self-cleaning properties (Cassie–Baxter state) and the robustness of the superhydrophobic properties (stability of the Cassie–Baxter state). This review will allow researchers to envisage new ideas and industrialists to advance in the commercialization of these materials.
 A1  - Darmanin, Thierry
 A1  - Guittard, Frederic
@@ -1865,7 +1865,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1754-5692
 DO  - 10.1039/C7EE03165C
 M3  - 10.1039/C7EE03165C
-UR  - http://dx.doi.org/10.1039/C7EE03165C
+UR  - https://doi.org/10.1039/C7EE03165C
 N2  - The sharp increase of research passion in the new-generation solar cells in recent years has resulted in a new trend in combining multiple types of energy devices in a single device. In view of the enhanced and/or diversified function of integrated devices, as compared with conventional devices with limited performance or sole applicability, many integrated power packs have been widely developed by combining different devices, such as a silicon solar cell (SSC), Cu(In,Ga)(Sn,Se)2 (CIGS), organic solar cell (OSC), dye-sensitized solar cell (DSSC), perovskite solar cell (PSC), lithium-ion battery (LIB), nanogenerator (NG), supercapacitor (SC), photoelectrosynthetic cell (PESC), and electrolysis cell (ELC), into one unit. In this Review, with a particular emphasis on their recent advances, we cover the integrated solar cell device research in a broad sense and provide an overview of state-of-the-art progress on the integrated solar cell devices based on DSSC and PSC, such as DSSC/LIB, DSSC/SC, DSSC/NG, DSSC/LIB/NG, PSC/OSC, PSC/CIGS, PSC/PSC, PSC/SSC, SSC/SC, PSC/SC, OSC/SC, DSSC/PESC, PSC/PESC, and PSC/ELC, for energy harvesting and storage that are significantly important for self-powering systems and portable/wearable electronics. Finally, the challenges and future outlooks in this promising photovoltaic (PV) field are featured on the basis of current development.
 A1  - Yun, Sining
 A1  - Qin, Yong
@@ -1891,7 +1891,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C7CS00104E
 M3  - 10.1039/C7CS00104E
-UR  - http://dx.doi.org/10.1039/C7CS00104E
+UR  - https://doi.org/10.1039/C7CS00104E
 N2  - Carbon nanotubes (CNTs) have attracted worldwide research interest in the past two decades owing to their extraordinary properties and wide applications in numerous fields. Among various types of CNTs, the horizontally aligned CNT (HACNT) arrays, which consist of CNTs grown on flat substrates and parallel with each other with large intertube distances and lengths up to centimeters, show many advantages due to their perfect structures and extraordinary mechanical, thermal and electrical properties. HACNTs show great potential as building blocks for transparent displays, nano electronics, quantum lines, field emission transistors, superstrong tethers, aeronautics and astronics materials, and even space elevators. During the past years, great progress has been achieved in HACNT research. In this review, we systematically review the growth mechanism, structure control, morphology control, characterization, manipulation, properties, and applications of HACNTs. Finally, we present a summary and outlook for the future development of HACNTs. We hope these advances will shed light on the future study of HACNTs.
 A1  - Zhang, Rufan
 A1  - Zhang, Yingying
@@ -1912,7 +1912,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C4TA00902A
 M3  - 10.1039/C4TA00902A
-UR  - http://dx.doi.org/10.1039/C4TA00902A
+UR  - https://doi.org/10.1039/C4TA00902A
 N2  - Flexible Dye Solar Cells (FDSCs), in their most widespread architecture, are assembled with two opposing planar films or foil substrates in metal–plastic or plastic–plastic combinations. The use of one metal electrode enables the convenient utilization of materials and high temperature processes but is accompanied by issues including partial opacity of the electrolyte and catalyst layer. Constraints on the stability of plastic substrates have led to the development of a variety of alternative material formulations and processes to guarantee performance even at low temperatures compatible with plastic films. Recently, efforts in doing without transparent conducting oxides have led to the development of new unconventional architectures. Review of the operation of DSCs shows that initial target markets are represented by indoor applications where power output densities have been shown to outperform competing flexible photovoltaic technologies. Whereas performance, stability in particular, needs to be significantly improved for the adoption in long term outdoor installations, commercial products integrating FDCSs for indoor or portable use have already been launched. Issues pertaining progress in materials, processes, devices and industrialization of FDSCs will be analyzed and discussed in this review.
 A1  - Brown, T. M.
 A1  - Rossi, F. De
@@ -1937,7 +1937,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C6CS00752J
 M3  - 10.1039/C6CS00752J
-UR  - http://dx.doi.org/10.1039/C6CS00752J
+UR  - https://doi.org/10.1039/C6CS00752J
 N2  - Dye-sensitized solar cells (DSSCs) are regarded as prospective solar cells for the next generation of photovoltaic technologies and have become research hotspots in the PV field. The counter electrode, as a crucial component of DSSCs, collects electrons from the external circuit and catalyzes the redox reduction in the electrolyte, which has a significant influence on the photovoltaic performance, long-term stability and cost of the devices. Solar cells, dye-sensitized solar cells, as well as the structure, principle, preparation and characterization of counter electrodes are mentioned in the introduction section. The next six sections discuss the counter electrodes based on transparency and flexibility, metals and alloys, carbon materials, conductive polymers, transition metal compounds, and hybrids, respectively. The special features and performance, advantages and disadvantages, preparation, characterization, mechanisms, important events and development histories of various counter electrodes are presented. In the eighth section, the development of counter electrodes is summarized with an outlook. This article panoramically reviews the counter electrodes in DSSCs, which is of great significance for enhancing the development levels of DSSCs and other photoelectrochemical devices.
 A1  - Wu, Jihuai
 A1  - Lan, Zhang
@@ -1965,7 +1965,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0959-9428
 DO  - 10.1039/C0JM00681E
 M3  - 10.1039/C0JM00681E
-UR  - http://dx.doi.org/10.1039/C0JM00681E
+UR  - https://doi.org/10.1039/C0JM00681E
 N2  - Uniform Cu2Cl(OH)3 and Cu2(NO3)(OH)3 nanoparticles are firstly prepared and characterized based on various analytical tools (i.e. DLS, SEM, XRD, FT-IR, UV-Vis, and DTA-TG). Accordingly, Cu2Cl(OH)3 and Cu2(NO3)(OH)3 exhibit mean diameters of 51 nm and 37 nm, respectively. Both nanomaterials show a bright green colour with the maxima of absorption at 505 nm (Cu2Cl(OH)3) and 503 nm (Cu2(NO3)(OH)3). Thermally Cu2Cl(OH)3 and Cu2(NO3)(OH)3 decompose below 600 °C and 240 °C, respectively, to form CuO. In addition, as-prepared Cu2Cl(OH)3 and Cu2(NO3)(OH)3 nanoparticles can be reduced to form copper metal at room temperature. While depositing/printing suspensions of the as-prepared nanoparticles in ethanol on silicon wafers, glass plates or paper, NaBH4-driven reduction leads to highly conductive copper thin-films. Namely these thin-films exhibit sheet resistances of 3–10 Ω□ and specific resistances of 1.3–4.3 × 10−3 Ω cm, which matches with the resistivity of bulk copper metal (1.7 × 10−3 Ω cm).
 A1  - Wolf, Silke
 A1  - Feldmann, Claus
@@ -1985,7 +1985,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C3CS60348B
 M3  - 10.1039/C3CS60348B
-UR  - http://dx.doi.org/10.1039/C3CS60348B
+UR  - https://doi.org/10.1039/C3CS60348B
 N2  - As important opto-electronical devices, nanofilm photodetectors constructed from inorganic low-dimensional nanostructures have drawn prime attention due to their significance in basic scientific research and potential technological applications. This review highlights a selection of important topics pertinent to inorganic nanofilm photodetectors processed via solution strategies. This article begins with a description of the advantages and drawbacks of nanofilm-based photodetectors versus 1D nanostructure-based ones, and then introduces rational design and controlled syntheses of various nanofilms via different wet-chemical routes, and then mainly focuses on their optoelectronic properties and applications in photodetectors based on the different types of nanofilms. Finally, the general challenges and the potential future directions of this exciting research and technology area are presented.
 A1  - Wang, Xi
 A1  - Tian, Wei
@@ -2008,7 +2008,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C8CS00417J
 M3  - 10.1039/C8CS00417J
-UR  - http://dx.doi.org/10.1039/C8CS00417J
+UR  - https://doi.org/10.1039/C8CS00417J
 N2  - During the last decade, two-dimensional materials (2DMs) have attracted great attention due to their unique chemical and physical properties, which make them appealing platforms for diverse applications in opto-electronic devices, energy generation and storage, and sensing. Among their various extraordinary properties, 2DMs possess high surface area-to-volume ratios and ultra-high surface sensitivity to the environment, which are key characteristics for applications in chemical sensing. Furthermore, 2DMs’ superior electrical and optical properties, combined with their excellent mechanical characteristics such as robustness and flexibility, make these materials ideal components for the fabrication of a new generation of high-performance chemical sensors. Depending on the specific device, 2DMs can be tailored to interact with various chemical species at the non-covalent level, making them powerful platforms for fabricating devices exhibiting a high sensitivity towards detection of various analytes including gases, ions and small biomolecules. Here, we will review the most enlightening recent advances in the field of chemical sensors based on atomically-thin 2DMs and we will discuss the opportunities and the challenges towards the realization of novel hybrid materials and sensing devices.
 A1  - Anichini, Cosimo
 A1  - Czepa, Włodzimierz
@@ -2032,7 +2032,7 @@ PB  - The Royal Society of Chemistry
 SN  - current
 DO  - 10.1039/C8QM00356D
 M3  - 10.1039/C8QM00356D
-UR  - http://dx.doi.org/10.1039/C8QM00356D
+UR  - https://doi.org/10.1039/C8QM00356D
 N2  - High-quality personalized medicine and health management have increasingly demanded wearable biomedical electronic devices (WBEDs) towards being more flexible and stretchable. This modern-life oriented trend has driven tremendous efforts from both academia and industrial enterprises devoted to research and development of new-generation WBEDs for improving the quality of home medicine. The development of such WBEDs crucially depends on design and assembly of new-types of materials. Thanks to superior physicochemical properties derived by their two-dimensional (2D) layered structural nature, 2D layered nanomaterials (2DLNs) hold notable advantages and are offering a promising material platform for energy, sensing, and wearable electronic applications. By using 2DLNs as versatile building modules, a number of technical breakthroughs have recently been achieved for manufacturing state-of-the-art 2DLNs-supported flexible/stretchable sensors and power devices, which could help WBEDs further achieve enhanced flexibility/stretchability and realize remarkable performance improvements. This review aims to offer timely and comprehensive evaluations of the current status, remaining challenges, and future perspectives of 2DLNs-supported wearable biomedical sensors and power devices, with the emphasis on the latest advancements and the significance of 2DLNs in device design and fabrication.
 A1  - Cao, Xianyi
 A1  - Halder, Arnab
@@ -2057,7 +2057,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C4CS00106K
 M3  - 10.1039/C4CS00106K
-UR  - http://dx.doi.org/10.1039/C4CS00106K
+UR  - https://doi.org/10.1039/C4CS00106K
 N2  - The assembly of metal ions with organic ligands through the formation of coordination bonds gives crystalline framework materials, known as metal–organic frameworks (MOFs), which recently emerged as a new class of porous materials. Besides the structural designability of MOFs at the molecular length scale, the researchers in this field very recently made important advances in creating more complex architectures at the mesoscopic/macroscopic scale, in which MOF nanocrystals are used as building units to construct higher-order superstructures. The structuring of MOFs in such a hierarchical order certainly opens a new opportunity to improve the material performance via design of the physical form rather than altering the chemical component. This review highlights these superstructures and their applications by categorizing them into four dimensionalities, zero-dimensional (0D), one-dimensional (1D), two-dimensional (2D), and three-dimensional (3D) superstructures. Because the key issue for structuring of MOFs is to spatially control the nucleation process in desired locations, this review conceptually categorizes the available synthetic methodologies from the viewpoint of the reaction system.
 A1  - Furukawa, Shuhei
 A1  - Reboul, Julien
@@ -2080,7 +2080,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C7CS00271H
 M3  - 10.1039/C7CS00271H
-UR  - http://dx.doi.org/10.1039/C7CS00271H
+UR  - https://doi.org/10.1039/C7CS00271H
 N2  - Encoded nano-structures/particles have been used for barcoding and are in great demand for the simultaneous analysis of multiple targets. Due to their nanoscale dimension(s), nano-barcodes have been implemented favourably for bioimaging, in addition to their security and multiplex bioassay application. In designing nano-barcodes for a specific application, encoding techniques, synthesis strategies, and decoding techniques need to be considered. The encoding techniques to generate unique multiple codes for nano-barcodes are based on certain encoding elements including optical (fluorescent and non-fluorescent), graphical, magnetic, and phase change properties of nanoparticles or their different shapes and sizes. These encoding elements can generally be embedded inside, decorated on the surface of nanostructures or self-assembled to prepare the nano-barcodes. The decoding techniques for each encoding technique are different and need to be suitable for the desired applications. This review will provide a thorough discussion on designing nano-barcodes, focusing on the encoding techniques, synthesis methods, and decoding for applications including bio-detection, imaging, and anti-counterfeiting. Additionally, associated challenges in the field and potential solutions will also be discussed. We believe that a comprehensive understanding on this topic could significantly contribute towards the advancement of nano-barcodes for a broad spectrum of applications.
 A1  - Shikha, Swati
 A1  - Salafi, Thoriq
@@ -2102,7 +2102,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C5TC04364F
 M3  - 10.1039/C5TC04364F
-UR  - http://dx.doi.org/10.1039/C5TC04364F
+UR  - https://doi.org/10.1039/C5TC04364F
 N2  - High-throughput patterning and enhanced mechanical stability are key to enabling large-area applications of metal nanowire mesh transparent electrodes. In this work, hybrid transparent conductors based on silver nanowires embedded in an indium zinc oxide matrix were prepared by high-speed gravure-printing (1.0 m s−1) from a single, stable liquid precursor. These gravure-printed films demonstrate excellent conductivity (9.3 Ω □−1) and transparency (T550nm ∼ 91%), as well as robust mechanical properties. The encapsulating indium zinc oxide matrix dramatically improves adhesion, surface roughness (Rq < 5 nm), film uniformity, and thermal stability (up to 350 °C) of the embedded silver nanowires. These properties of the hybrid films make them a suitable electrode material for a variety of printed electronic devices, such as flexible OLEDs and solar cells.
 A1  - Scheideler, William J.
 A1  - Smith, Jeremy
@@ -2126,7 +2126,7 @@ PB  - The Royal Society of Chemistry
 SN  - current
 DO  - 10.1039/C4RA00506F
 M3  - 10.1039/C4RA00506F
-UR  - http://dx.doi.org/10.1039/C4RA00506F
+UR  - https://doi.org/10.1039/C4RA00506F
 N2  - Here, we have reviewed brief ideas of fabrication of superhydrophobic surfaces and their important applications, which were discussed in the concluded national/international workshops and conferences organized by different industries and laboratories of ISRO (Indian Space Research Organization), DRDO (Defence Research and Development Organization) and AERB (Atomic Energy Regulatory Board) in the last four years. A comprehensive overview of wettability, development of fabrication, techniques for artificial superhydrophobic surfaces and their natures and low surface energy materials along with surface texture is presented successfully. The purpose of this review is to assist future development to make robust superhydrophobic surfaces.
 A1  - Sahoo, Bichitra Nanda
 A1  - Kandasubramanian, Balasubramanian
@@ -2146,7 +2146,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C5TA01228G
 M3  - 10.1039/C5TA01228G
-UR  - http://dx.doi.org/10.1039/C5TA01228G
+UR  - https://doi.org/10.1039/C5TA01228G
 N2  - Carbothermal reduction could be employed as a facile technology for the synthesis of various novel materials, especially transition-metal-functionalized nanostructures. In particular, energy materials, such as ZnO, MnO2, and LiFePO4, combined with different carbon nanostructures have been widely synthesized via carbothermal reduction, which could be well established industrially due to its low-cost starting materials. In addition, a variety of carbon sources can be employed as comparatively low-cost carbon precursors for the synthesis of carbonaceous functional materials, such as porous carbon-coated magnetic nanoparticles (e.g., Co3O4@C, Fe3O4@C, and FeC3–C). These functional materials have great potential for use in energy and environmental applications. Carbothermal reduction methods possess some incomparable advantages, such as convenience, relatively low cost, and good repeatability, for commercial applications. However, they normally require a relatively high temperature for sustaining carbothermic reaction. Consequently, novel structures can also be derived from renewable, abundant carbon precursors. Examples include lignocellulosic biomass or other biological products derived from food or agricultural wastes (carbohydrates, cellulose, hemicellulose, lignin, chitin, inorganics, and proteins). Thermochemical conversion of biomass, including pyrolysis in an inert environment, has been developed for the production of energy and carbon materials. Furthermore, it is still a potential challenge to simultaneously produce high-quality biofuel products and synthesize value-added functionalized materials via in situ carbothermal reduction. This review will be a powerful resource for stimulating the development of sustainable metal-functionalized nanostructured materials by carbothermal reduction integrated with other advanced technologies, particularly for strengthening efforts towards novel materials for clean energy and environmental applications in the future sustainable society.
 A1  - Shen, Yafei
 ER  - 
@@ -2165,7 +2165,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1744-683X
 DO  - 10.1039/B711984D
 M3  - 10.1039/B711984D
-UR  - http://dx.doi.org/10.1039/B711984D
+UR  - https://doi.org/10.1039/B711984D
 N2  - Inkjet printing is an attractive patterning technology, which has become increasingly accepted for a variety of industrial and scientific applications. This review primarily presents an overview of the investigations that have been conducted since 2003 into inkjet-printing polymers or metal-containing inks and mentions related activities. The first section discusses the droplet-formation process in piezoelectric drop-on-demand printheads and the physical properties that affect droplet formation and the resolution of inkjet-printed features. The second section deals with the issues that arise from printing polymers, such as printability and the output characteristics of devices made by this route. Finally, the challenges and achievements attached to inkjet printing metal-containing inks are discussed before concluding with a few remarks about the future of the field.
 A1  - Tekin, Emine
 A1  - Smith, Patrick J.
@@ -2186,7 +2186,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0267-9477
 DO  - 10.1039/B915056K
 M3  - 10.1039/B915056K
-UR  - http://dx.doi.org/10.1039/B915056K
+UR  - https://doi.org/10.1039/B915056K
 N2  - This is the latest review covering atomic spectrometric activities using XRF techniques. It offers a comprehensive review of instrumentation and detectors, matrix correction and spectrum analysis procedures, X-ray optics and micro-fluorescence, SRXRF, TXRF plus handheld and portable XRF as assessed from the published literature. As techniques mature, the application sections have expanded to report developments in sample preparation, geological and industrial minerals, environmental, archaeological, forensic, biological, clinical, thin films, chemical state and speciation studies. They also reflect how the XRF technique is increasingly being used to provide analytical measurements that are then combined with results from more specialised techniques to report comprehensive material characterisation. The commercial availability of silicon drift detectors (SDD) has transformed the handheld EDXRF market this year by extending in situ analytical capabilities down to magnesium. Imaging techniques that provide either 2D or 3D mapping facilities continue to feature this year along with further developments in SR and TXRF systems. The writing team would welcome feedback from readers of this review and invite you to complete the Atomic Spectrometry Updates questionnaire at http://www.asureviews.org.
 A1  - West, Margaret
 A1  - Ellis, Andrew T.
@@ -2211,7 +2211,7 @@ PB  - The Royal Society of Chemistry
 SN  - current
 DO  - 10.1039/C8QM00270C
 M3  - 10.1039/C8QM00270C
-UR  - http://dx.doi.org/10.1039/C8QM00270C
+UR  - https://doi.org/10.1039/C8QM00270C
 N2  - Portable electronic devices and electric vehicles have greatly stimulated the development of micro-sized energy storage devices. Electrochemical capacitors, which have the abilities of rapid charge and discharge, high energy storage and outstanding cyclic stability, can bridge the gap between batteries and conventional electrolytic capacitors. Graphene, an emerging two-dimensional (2D) material, is an excellent choice to fabricate electrodes. With the abovementioned abilities, graphene-based microsupercapacitors (graphene-based MSCs) are promising future energy storage devices to promote the practical application of portable electronics and microelectronic devices. This review aims to summarize the latest developments in graphene-based MSCs and the methods of processing miniature graphene electrodes to provide higher performance. In addition, we are also committed to critically analyzing the status of graphene-based MSCs and, on this basis, forecasting their future challenges, perspectives and opportunities.
 A1  - Zhang, Guofeng
 A1  - Han, Yuyang
@@ -2239,7 +2239,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C3CS60054H
 M3  - 10.1039/C3CS60054H
-UR  - http://dx.doi.org/10.1039/C3CS60054H
+UR  - https://doi.org/10.1039/C3CS60054H
 N2  - Nanochemistry and nanomaterials provide numerous opportunities for a new generation of photovoltaics with high solar energy conversion efficiencies at low fabrication cost. Quantum-confined nanomaterials and polymer–inorganic nanocomposites can be tailored to harvest sun light over a broad range of the spectrum, while plasmonic structures offer effective ways to reduce the thickness of light-absorbing layers. Multiple exciton generation, singlet exciton fission, photon down-conversion, and photon up-conversion realized in nanostructures, create significant interest for harvesting underutilized ultraviolet and currently unutilized infrared photons. Nanochemical interface engineering of nanoparticle surfaces and junction-interfaces enable enhanced charge separation and collection. In this review, we survey these recent advances employed to introduce new concepts for improving the solar energy conversion efficiency, and reduce the device fabrication cost in photovoltaic technologies. The review concludes with a summary of contributions already made by nanochemistry. It then describes the challenges and opportunities in photovoltaics where the chemical community can play a vital role.
 A1  - Chen, Guanying
 A1  - Seo, Jangwon
@@ -2261,7 +2261,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1754-5692
 DO  - 10.1039/C3EE41981A
 M3  - 10.1039/C3EE41981A
-UR  - http://dx.doi.org/10.1039/C3EE41981A
+UR  - https://doi.org/10.1039/C3EE41981A
 N2  - Among the armoury of photovoltaic materials, thin film heterojunction photovoltaics continue to be a promising candidate for solar energy conversion delivering a vast scope in terms of device design and fabrication. Their production does not require expensive semiconductor substrates and high temperature device processing, which allows reduced cost per unit area while maintaining reasonable efficiency. In this regard, superstrate CdTe/CdS solar cells are extensively investigated because of their suitable bandgap alignments, cost effective methods of production at large scales and stability against proton/electron irradiation. The conversion efficiencies in the range of 6–20% are achieved by structuring the device by varying the absorber/window layer thickness, junction activation/annealing steps, with more suitable front/back contacts, preparation techniques, doping with foreign ions, etc. This review focuses on fundamental and critical aspects like: (a) choice of CdS window layer and CdTe absorber layer; (b) drawbacks associated with the device including environmental problems, optical absorption losses and back contact barriers; (c) structural dynamics at CdS–CdTe interface; (d) influence of junction activation process by CdCl2 or HCF2Cl treatment; (e) interface and grain boundary passivation effects; (f) device degradation due to impurity diffusion and stress; (g) fabrication with suitable front and back contacts; (h) chemical processes occurring at various interfaces; (i) strategies and modifications developed to improve their efficiency. The complexity involved in understanding the multiple aspects of tuning the solar cell efficiency is reviewed in detail by considering the individual contribution from each component of the device. It is expected that this review article will enrich the materials aspects of CdTe/CdS devices for solar energy conversion and stimulate further innovative research interest on this intriguing topic.
 A1  - Kumar, S. Girish
 A1  - Rao, K. S. R. Koteswara
@@ -2281,7 +2281,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1359-7345
 DO  - 10.1039/C2CC30792H
 M3  - 10.1039/C2CC30792H
-UR  - http://dx.doi.org/10.1039/C2CC30792H
+UR  - https://doi.org/10.1039/C2CC30792H
 N2  - Power generation through photovoltaics (PV) has been growing at an average rate of 40% per year over the last decade; but has largely been fuelled by conventional Si-based technologies. Such cells involve expensive processing and many alternatives use either toxic, less-abundant and or expensive elements. Kesterite Cu2ZnSnS4 (CZTS) has been identified as a solar energy material composed of both less toxic and more available elements. Power conversion efficiencies of 8.4% (vacuum processing) and 10.1% (non-vacuum processing) from cells constructed using CZTS have been achieved to date. In this article, we review various deposition methods for CZTS thin films and the synthesis of CZTS nanoparticles. Studies of direct relevance to solar cell applications are emphasised and characteristic properties are collated.
 A1  - Ramasamy, Karthik
 A1  - Malik, Mohammad A.
@@ -2302,7 +2302,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C7CS00043J
 M3  - 10.1039/C7CS00043J
-UR  - http://dx.doi.org/10.1039/C7CS00043J
+UR  - https://doi.org/10.1039/C7CS00043J
 N2  - Post-transition elements, together with zinc-group metals and their alloys belong to an emerging class of materials with fascinating characteristics originating from their simultaneous metallic and liquid natures. These metals and alloys are characterised by having low melting points (i.e. between room temperature and 300 °C), making their liquid state accessible to practical applications in various fields of physical chemistry and synthesis. These materials can offer extraordinary capabilities in the synthesis of new materials, catalysis and can also enable novel applications including microfluidics, flexible electronics and drug delivery. However, surprisingly liquid metals have been somewhat neglected by the wider research community. In this review, we provide a comprehensive overview of the fundamentals underlying liquid metal research, including liquid metal synthesis, surface functionalisation and liquid metal enabled chemistry. Furthermore, we discuss phenomena that warrant further investigations in relevant fields and outline how liquid metals can contribute to exciting future applications.
 A1  - Daeneke, T.
 A1  - Khoshmanesh, K.
@@ -2328,7 +2328,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C7TA05759H
 M3  - 10.1039/C7TA05759H
-UR  - http://dx.doi.org/10.1039/C7TA05759H
+UR  - https://doi.org/10.1039/C7TA05759H
 N2  - In recent years, the technological advancement of supercapacitors has been increasing exponentially due to the high demand in electronic consumer products. As so, researchers have found a way to meet that demand by fabricating graphene. As developments are made toward the future, two big advancements to be made are large-scale fabrication of graphene and fabricating graphene as a flexible electrode. This would allow for use in larger products and for manipulation of the unique properties of graphene to accommodate superior design alternatives. While large scale production is still mentioned, this review is specifically focusing on different methods used to fabricate graphene as a flexible electrode. Various fabrication methods, such as Hummers' method, chemical vapor deposition, epitaxial growth, and exfoliation of graphite oxide, used to fabricate graphene in such a way that allows flexibility and utilization of graphene's mechanical and electrical properties are discussed. Additionally, a section on environmentally friendly fabrication approaches is presented and discussed.
 A1  - Tan, Russell Kai Liang
 A1  - Reeves, Sean P.
@@ -2353,7 +2353,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C8CS00084K
 M3  - 10.1039/C8CS00084K
-UR  - http://dx.doi.org/10.1039/C8CS00084K
+UR  - https://doi.org/10.1039/C8CS00084K
 N2  - Graphene and related two-dimensional materials provide an ideal platform for next generation disruptive technologies and applications. Exploiting these solution-processed two-dimensional materials in printing can accelerate this development by allowing additive patterning on both rigid and conformable substrates for flexible device design and large-scale, high-speed, cost-effective manufacturing. In this review, we summarise the current progress on ink formulation of two-dimensional materials and the printable applications enabled by them. We also present our perspectives on their research and technological future prospects.
 A1  - Hu, Guohua
 A1  - Kang, Joohoon
@@ -2379,7 +2379,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7488
 DO  - 10.1039/C8TA02159G
 M3  - 10.1039/C8TA02159G
-UR  - http://dx.doi.org/10.1039/C8TA02159G
+UR  - https://doi.org/10.1039/C8TA02159G
 N2  - Perovskite solar cells, based on halide light absorbers with a perovskite crystal structure, have been the focus of research since their development in 2009 due to their well-known outstanding characteristics, such as high power conversion efficiency, low cost, and easy fabrication processes. Recently, a number of efforts have been made to commercialize perovskite solar cells. In this article, we review recent efforts to fabricate modularized perovskite solar cells, to develop techniques for large scale fabrication and multiple functions, and to decrease toxicity.
 A1  - Kim, Byeong Jo
 A1  - Lee, Sangwook
@@ -2400,7 +2400,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C4NR01954G
 M3  - 10.1039/C4NR01954G
-UR  - http://dx.doi.org/10.1039/C4NR01954G
+UR  - https://doi.org/10.1039/C4NR01954G
 N2  - Atomic layer deposition (ALD) is a method that allows for the deposition of thin films with atomic level control of the thickness and an excellent conformality on 3-dimensional surfaces. In recent years, ALD has been implemented in many applications in microelectronics, for which often a patterned film instead of full area coverage is required. This article reviews several approaches for the patterning of ALD-grown films. In addition to conventional methods relying on etching, there has been much interest in nanopatterning by area-selective ALD. Area-selective approaches can eliminate compatibility issues associated with the use of etchants, lift-off chemicals, or resist films. Moreover, the use of ALD as an enabling technology in advanced nanopatterning methods such as spacer defined double patterning or block copolymer lithography is discussed, as well as the application of selective ALD in self-aligned fabrication schemes.
 A1  - Mackus, A. J. M.
 A1  - Bol, A. A.
@@ -2421,7 +2421,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C8TC02230E
 M3  - 10.1039/C8TC02230E
-UR  - http://dx.doi.org/10.1039/C8TC02230E
+UR  - https://doi.org/10.1039/C8TC02230E
 N2  - Health self-monitoring systems that can automatically recognize health information and respond in real-time through wearable sensors and artificial intelligence are one of the major development issues of the fourth industrial revolution. To realize such health self-monitoring systems, it is essential to develop wearable sensors that can detect biophysical signals from the human body. Organic sensors based on organic semiconductors or conductive materials are receiving a lot of attention as wearable sensors for health self-monitoring systems due to the advantages of their flexibility, stretchability, low cost, and light weight. Here, we review recent developments in organic sensors for health monitoring and methods for improving their performance.
 A1  - Lee, Yoon Ho
 A1  - Kweon, O. Young
@@ -2445,7 +2445,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C8CS00254A
 M3  - 10.1039/C8CS00254A
-UR  - http://dx.doi.org/10.1039/C8CS00254A
+UR  - https://doi.org/10.1039/C8CS00254A
 N2  - Extensive research on two-dimensional (2D) materials has triggered the renaissance of an old topic, that is, the intercalation and exfoliation of layer materials. Such top-down exfoliation produced 2D materials and their dispersions have several advantages including low cost, scalable production capability, solution processability, and versatile functionalities stemming from the large number of species of layer materials, and show promising potential in many applications. In recent years, many new methods have been developed for exfoliating layer materials to 2D materials for different application purposes. In this review the different exfoliation approaches are first systematically analyzed from the viewpoint of methodology, and the advantages and disadvantages of each method are compared. Second, the assembly of exfoliated 2D materials into macrostructures by solution-based techniques is summarized. Third, the state-of-the-art applications of 2D material dispersions and their assemblies in electronics and optoelectronics, electrocatalysis, energy storage, etc., are discussed. Finally, insights and perspectives on current research challenges and future opportunities regarding the exfoliation and applications of 2D materials in dispersions are considered.
 A1  - Cai, Xingke
 A1  - Luo, Yuting
@@ -2467,7 +2467,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C7TC00664K
 M3  - 10.1039/C7TC00664K
-UR  - http://dx.doi.org/10.1039/C7TC00664K
+UR  - https://doi.org/10.1039/C7TC00664K
 N2  - Both organic semiconductors and graphene now represent an established field of research with great technological potential. Recently, impressive progress has been made in our understanding of how to synergistically exploit their basic properties as unique functions in practical applications. It is therefore time to regard hybrid electronics from organic semiconductors and graphene as a distinct subject of research that may open up many new possibilities. This article reviews fundamental aspects and recent advances in emerging devices, and projects our perspectives on their future.
 A1  - Kim, Chang-Hyun
 A1  - Kymissis, Ioannis
@@ -2487,7 +2487,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1359-7345
 DO  - 10.1039/C8CC05368E
 M3  - 10.1039/C8CC05368E
-UR  - http://dx.doi.org/10.1039/C8CC05368E
+UR  - https://doi.org/10.1039/C8CC05368E
 N2  - Compared to tedious, multi-step treatments for electroless gold plating of traditional thermoplastics, this communication describes a simpler three-step procedure for 3D printed crosslinked polyacrylate substrates. This allows for the synthesis of ultralight gold foam microlattice materials with great potential for architecture-sensitive applications in future energy, catalysis, and sensing.
 A1  - Kim, Sung Ho
 A1  - Jackson, Julie A.
@@ -2518,7 +2518,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C3NR04968J
 M3  - 10.1039/C3NR04968J
-UR  - http://dx.doi.org/10.1039/C3NR04968J
+UR  - https://doi.org/10.1039/C3NR04968J
 N2  - The unique properties of graphene make it a promising material for interconnects in flexible and transparent electronics. To increase the commercial impact of graphene in those applications, a scalable and economical method for producing graphene patterns is required. The direct synthesis of graphene from an area-selectively passivated catalyst substrate can generate patterned graphene of high quality. We here present a solution-based method for producing patterned passivation layers. Various deposition methods such as ink-jet deposition and microcontact printing were explored, that can satisfy application demands for low cost, high resolution and scalable production of patterned graphene. The demonstrated high quality and nanometer precision of grown graphene establishes the potential of this synthesis approach for future commercial applications of graphene. Finally, the ability to transfer high resolution graphene patterns onto complex three-dimensional surfaces affords the vision of graphene-based interconnects in novel electronics.
 A1  - Hofmann, Mario
 A1  - Hsieh, Ya-Ping
@@ -2540,7 +2540,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1754-5692
 DO  - 10.1039/C4EE01724B
 M3  - 10.1039/C4EE01724B
-UR  - http://dx.doi.org/10.1039/C4EE01724B
+UR  - https://doi.org/10.1039/C4EE01724B
 N2  - Dye-sensitized solar cells (DSCs) are well researched globally due to their potential as low-cost photovoltaic (PV) devices especially suited for building and automobile integrated PV (BIPV, AIPV) and portable or indoor light harvesting applications. Since 1991, large monetary and intellectual investments have been made to develop DSCs into deployable technologies, creating a wealth of knowledge about nano-interfaces and devices through an increasing number of research reports. In response to these investments, the dawn of the new millennium witnessed the emergence of a corporate sector of DSC development. Advances in their design, their incorporation on flexible substrates, the development of solid state modules, their enhanced stability in outdoor environments, and their scalable fabrication tools and techniques have allowed DSCs to move from the laboratory to real-life applications. Although photoconversion efficiencies are not on a par with commercially available CIGS or single crystalline silicon solar cells, they possess many features that compel the further development of DSC modules, including transparency, light weight, flexibility, conformability, workability under low-light conditions, and easy integration in buildings as solar windows. In fact, DSC panels have been shown to deliver even more electricity than their silicon and thin film counterparts of similar power ratings when exposed to low light operating conditions due to their workability in such conditions; thus, they are potential market leaders in BIPV and indoor light harvesting photovoltaic technology. However, large area dye-solar modules lack in performance compared to their laboratory scale devices and also suffer from long term stability issues. Herein, we discuss the main factors behind their inferior photovoltaic performance and identify possible opportunities for the design of more efficient DSC modules.
 A1  - Fakharuddin, Azhar
 A1  - Jose, Rajan
@@ -2563,7 +2563,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0306-0012
 DO  - 10.1039/C2CS35369E
 M3  - 10.1039/C2CS35369E
-UR  - http://dx.doi.org/10.1039/C2CS35369E
+UR  - https://doi.org/10.1039/C2CS35369E
 N2  - Templating is one of the most important techniques for the controlled synthesis of nanostructured materials. This powerful tool uses a pre-existing guide with desired nanoscale features to direct the formation of nanomaterials into forms that are otherwise difficult to obtain. As a result, templated synthesis is capable of producing nanostructures with unique structures, morphologies and properties. In this review, we summarize the general principles of templated synthesis and cover recent developments in this area. As a wide variety of synthesis techniques are utilized to produce nanomaterials using template-based methods, the discussion is organized around the various types of common templates. We examine the use of both physical and chemical hard colloidal templates, soft templates, and other non-colloidal templates, followed by our perspective on the state of the field and potential future directions.
 A1  - Liu, Yiding
 A1  - Goebl, James
@@ -2584,7 +2584,7 @@ PB  - The Royal Society of Chemistry
 SN  - 1473-0197
 DO  - 10.1039/C3LC50169H
 M3  - 10.1039/C3LC50169H
-UR  - http://dx.doi.org/10.1039/C3LC50169H
+UR  - https://doi.org/10.1039/C3LC50169H
 N2  - Dipstick and lateral-flow formats have dominated rapid diagnostics over the last three decades. These formats gained popularity in the consumer markets due to their compactness, portability and facile interpretation without external instrumentation. However, lack of quantitation in measurements has challenged the demand of existing assay formats in consumer markets. Recently, paper-based microfluidics has emerged as a multiplexable point-of-care platform which might transcend the capabilities of existing assays in resource-limited settings. However, paper-based microfluidics can enable fluid handling and quantitative analysis for potential applications in healthcare, veterinary medicine, environmental monitoring and food safety. Currently, in its early development stages, paper-based microfluidics is considered a low-cost, lightweight, and disposable technology. The aim of this review is to discuss: (1) fabrication of paper-based microfluidic devices, (2) functionalisation of microfluidic components to increase the capabilities and the performance, (3) introduction of existing detection techniques to the paper platform and (4) exploration of extracting quantitative readouts via handheld devices and camera phones. Additionally, this review includes challenges to scaling up, commercialisation and regulatory issues. The factors which limit paper-based microfluidic devices to become real world products and future directions are also identified.
 A1  - Yetisen, Ali Kemal
 A1  - Akram, Muhammad Safwan
@@ -2605,7 +2605,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2040-3364
 DO  - 10.1039/C4NR05108D
 M3  - 10.1039/C4NR05108D
-UR  - http://dx.doi.org/10.1039/C4NR05108D
+UR  - https://doi.org/10.1039/C4NR05108D
 N2  - Traditionally, magnetic field has long been regarded as an important means for studying the magnetic properties of materials. With the development of synthesis and assembly methods, magnetic field, similar to conventional reaction conditions such as temperature, pressure, and surfactant, has been developed as a new parameter for synthesizing and assembling special structures. To date, magnetic fields have been widely employed for materials synthesis and assembly of one-dimensional (1D), two-dimensional (2D) or three-dimensional (3D) aggregates. In this review, we aim to provide a summary on the applications of magnetic fields in this area. Overall, the objectives of this review are: (1) to theoretically discuss several factors that refer to magnetic field effects (MFEs); (2) to review the magnetic-field-induced synthesis of nanomaterials; the 1D structure of various nanomaterials, such as metal oxides/sulfide, metals, alloys, and carbon, will be described in detail. Moreover, the MFEs on spin states of ions, magnetic domain and product phase distribution will be also involved; (3) to review the alignment of carbon nanotubes, assembly of magnetic nanomaterials and photonic crystals with the help of magnetic fields; and (4) to sketch the future opportunities that magnetic fields can face in the area of materials synthesis and assembly.
 A1  - Hu, Lin
 A1  - Zhang, Ruirui
@@ -2626,7 +2626,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C8TC00307F
 M3  - 10.1039/C8TC00307F
-UR  - http://dx.doi.org/10.1039/C8TC00307F
+UR  - https://doi.org/10.1039/C8TC00307F
 N2  - Alternative transparent and conducting electrodes (TCEs) that can overcome the practical limitations of the existing TCEs have been explored. Although network structures of metal nanowires have been investigated for TCEs because of their excellent performance, characteristics such as high junction resistances, poor surface roughness, and randomly entangled NW networks still pose challenges. Here, we report cost-effective and solution-processable metallic mesh TCEs consisting of a Cu-mesh embedded in a flexible PDMS substrate. The unprecedented structures of the Cu-mesh TCEs offer considerable advantages over previous approaches, including high performance, surface smoothness, excellent flexibility, electromechanical stability, and thermal stability. Our Cu-mesh TCEs provide a transmittance of 96% at 550 nm and a sheet resistance of 0.1 Ω sq−1, as well as extremely high figures of merit, reaching up to 1.9 × 104, which are the highest reported values among recent studies. Finally, we demonstrate high-performance transparent heaters based on Cu-mesh TCEs and in situ color tuning of cholesteric liquid crystals (CLCs) using them, confirming the uniform spatial electrical conductivity as well as the reproducibility and reliability of the electrode.
 A1  - Han, Seolhee
 A1  - Chae, Yoonjeong
@@ -2654,7 +2654,7 @@ PB  - The Royal Society of Chemistry
 SN  - 2050-7526
 DO  - 10.1039/C3TC31302F
 M3  - 10.1039/C3TC31302F
-UR  - http://dx.doi.org/10.1039/C3TC31302F
+UR  - https://doi.org/10.1039/C3TC31302F
 N2  - The present work describes the inkjet printing and low temperature sintering of silver nanoparticle inks onto transfer tattoo paper. Our approach results in silver features of excellent resolution and conductivity and, subsequently the first passive UHF RFID transfer tattoo tags functional mounted on human skin of improved performance when compared to screen printed passive UHF RFID transfer tattoo paper tags. Moreover, inkjet printed passive UHF RFID transfer tattoo tags show similar performance to copper etched passive UHF RFID tags on plastic substrates. This study compares the image quality (resolution) and electrical performance of two commercial silver nanoparticle inks inkjet printed on transfer tattoo paper. The optimal printing and sintering parameters to obtain high resolution features of resistivities 20 to 57 times the resistivity of bulk silver (1.59 × 10−6 ohm cm) are described. We demonstrate how, by selectively depositing ink in specific areas of the antenna, read distance of passive UHF RFID tags can be increased from 54 to 68 cm whilst decreasing the amount of ink used by 33%. Furthermore, this approach results in inkjet printed passive UHF RFID tattoo tags with larger read distance than silver screen printed passive UHF RFID tattoo tags, 45 cm, and similar to copper etched passive UHF RFID plastic tags, 75 cm. Moreover, inkjet printed passive UHF RFID tattoo tags in this work are considerably thinner (1–5 μm) than screen and etched passive UHF RFID tags (tens of micrometers) hence, making the former more appealing to the end user. In addition to this, inkjet printing is compatible with large area manufacturing techniques and has the potential to evolve as one of the most promising RFID mass-production techniques. Therefore, this work represents a step towards the commercialization of on-body transfer tattoo paper passive UHF RFID tags.
 A1  - Sanchez-Romaguera, Veronica
 A1  - Ziai, Mohamed A.
@@ -2680,7 +2680,7 @@ PB  - The Royal Society of Chemistry
 SN  - current
 DO  - 10.1039/C7RA09921E
 M3  - 10.1039/C7RA09921E
-UR  - http://dx.doi.org/10.1039/C7RA09921E
+UR  - https://doi.org/10.1039/C7RA09921E
 N2  - In this study, we present solution-based processes for producing copper (Cu) meshes which can be utilized as transparent conductive electrodes (TCEs) for flexible film heaters. The surface modification of polyethylene terephthalate (PET) substrates was done via corona treatment at atmospheric pressure and room temperature. The Cu layer was deposited on the corona-treated PET substrate via electroless plating and then patterned via lithography to have mesh dimensions of a 200 μm line-to-line spacing and a 6 μm line width. Also, graphene was coated on the Cu mesh via electrophoretic deposition (EPD). The chemical and physical changes in the PET surfaces were characterized according to the corona treatment conditions. The measurements of contact angles and surface energies of the corona-treated PET substrates indicated that the PET surfaces changed from hydrophobic to hydrophilic after corona treatment, leading to the improvement in the adhesion between the PET substrates and the Cu meshes. The flexibility of the Cu meshes was inspected by performing bending and twisting tests and by directly measuring the adhesion strength between the Cu layers and the PET substrates through scratch tests. The effects of graphene coating on the characteristics of the Cu meshes were examined in terms of their surface morphologies, electrical sheet resistances, transmittances and reflectances in the visible-light wavelength range, and color differences. Finally, the film heaters produced by employing the graphene-coated Cu meshes yielded a temperature rise over 85 °C with a response time shorter than 20 s.
 A1  - Kim, Bu-Jong
 A1  - Park, Jong-Seol
@@ -2702,7 +2702,7 @@ PB  - The Royal Society of Chemistry
 SN  - current
 DO  - 10.1039/C6RA15292A
 M3  - 10.1039/C6RA15292A
-UR  - http://dx.doi.org/10.1039/C6RA15292A
+UR  - https://doi.org/10.1039/C6RA15292A
 N2  - Metallization of polymer materials is a crucial process in the manufacturing of decorative, wear-resistant and electromagnetic shielding coatings in the automotive, electronics and instrumentation industry. The core critical issues of the plastic plating process are cost-consumption by involving Pd activation and the interfacial bonding between metal layers and hydrocarbon surfaces. In this paper, metallization on hydrocarbon surfaces was achieved by depositing Ag films instead of palladium activation. The plating process was optimized and the Ag films' components and topography were studied by XRD and SEM, respectively. The common Cu plating process was carried out on Ag-coated ABS and a typical Cu layer formed with a thickness of 21.2 μm. From results of a scotch tape test and simple 90° peel test, the metal films are adhesive to plastic substrates. This proposed efficient Ag plating with enough adhesion holds promise to reduce both capital and operational costs of plastic surface metallization.
 A1  - Chen, Dexin
 A1  - Kang, Zhixin
@@ -2723,7 +2723,7 @@ PB  - The Royal Society of Chemistry
 SN  - 0959-9428
 DO  - 10.1039/B311061C
 M3  - 10.1039/B311061C
-UR  - http://dx.doi.org/10.1039/B311061C
+UR  - https://doi.org/10.1039/B311061C
 N2  - A novel approach for direct electroless (EL) patterning of copper films without catalysts has been developed. In a special electroless solution employed in the present study, the formation of copper particles was observed and the negatively charged surfaces were confirmed by zeta potential measurements. The conditions of the solution (ionic strength, pH, temperature, additives etc.) greatly affected the composition of the resulting precipitates. Results showed that pure copper films formed in EL solutions with pH higher than 7.3. A self-assembled monolayer (SAM) terminated with either NH2 or OH headgroups was employed as a template to enhance the selective adhesion of copper particles. As expected, many particles were deposited on the positive NH2-SAM by electrostatic attraction, while few particles were deposited on the negative OH-SAM due to repulsive interaction. The measurement results obtained by AFM, QCM, XRD and optical microscopy confirmed the selective formation of copper films on the NH2-SAM. Subsequently, micropatterns of copper films with high resolution were successfully produced. The deviation in the thickness of the deposit reached 110 nm between the NH2-SAM and OH-SAM after 90 min soaking in the EL solution. Current–voltage characteristics revealed relatively high resistivity (0.3 mΩ cm) of the formed copper film on the NH2-SAM, which can be ascribed to the poor connectivity among particles.
 A1  - Zhu, Peixin
 A1  - Masuda, Yoshitake

--- a/download-citation/pa.py
+++ b/download-citation/pa.py
@@ -110,7 +110,7 @@ def royal(url):
     citation_doi = bsop.find('meta', {'name':'citation_doi'}).attrs['content']
     PB = bsop.find('meta', {'name':'DC.publisher'}).attrs['content']
     M3 = citation_doi
-    citation_url = 'http://dx.doi.org/' + citation_doi
+    citation_url = 'https://doi.org/' + citation_doi
     citation_abstract = bsop.find('meta', {'name':'citation_abstract'}).attrs['content'].strip()
     SN = bsop.find('div', {'class':'article-nav__issue autopad--h'}).find('a').attrs['href'].split('=')[-1]
 

--- a/download-citation/pa1.py
+++ b/download-citation/pa1.py
@@ -60,7 +60,7 @@ def royal(article_urls):
         except:
             pass
         try:
-            citation_url = 'http://dx.doi.org/' + citation_doi
+            citation_url = 'https://doi.org/' + citation_doi
         except:
             pass
         try:

--- a/download-citation/ros.html
+++ b/download-citation/ros.html
@@ -68,7 +68,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 08 Jan 2018</span><br>
                 <span><i><strong>J. Mater. Chem. C</strong></i>, 2018,<span style='padding-right:2px'></span><strong>6</strong>, 1618-1641</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C7TC04804A">http://dx.doi.org/10.1039/C7TC04804A</a></span>
+                <span><a href="https://doi.org/10.1039/C7TC04804A">https://doi.org/10.1039/C7TC04804A</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -126,7 +126,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 03 May 2018</span><br>
                 <span><i><strong>Chem. Soc. Rev.</strong></i>, 2018,<span style='padding-right:2px'></span><strong>47</strong>, 4611-4641</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C7CS00192D">http://dx.doi.org/10.1039/C7CS00192D</a></span>
+                <span><a href="https://doi.org/10.1039/C7CS00192D">https://doi.org/10.1039/C7CS00192D</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -187,7 +187,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 06 Mar 2017</span><br>
                 <span><i><strong>J. Mater. Chem. C</strong></i>, 2017,<span style='padding-right:2px'></span><strong>5</strong>, 2971-2993</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C7TC00038C">http://dx.doi.org/10.1039/C7TC00038C</a></span>
+                <span><a href="https://doi.org/10.1039/C7TC00038C">https://doi.org/10.1039/C7TC00038C</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -249,7 +249,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 16 Oct 2017</span><br>
                 <span><i><strong>RSC Adv.</strong></i>, 2017,<span style='padding-right:2px'></span><strong>7</strong>, 48597-48630</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C7RA07191D">http://dx.doi.org/10.1039/C7RA07191D</a></span>
+                <span><a href="https://doi.org/10.1039/C7RA07191D">https://doi.org/10.1039/C7RA07191D</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -310,7 +310,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 16 May 2017</span><br>
                 <span><i><strong>Nanoscale</strong></i>, 2017,<span style='padding-right:2px'></span><strong>9</strong>, 7342-7372</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C7NR01604B">http://dx.doi.org/10.1039/C7NR01604B</a></span>
+                <span><a href="https://doi.org/10.1039/C7NR01604B">https://doi.org/10.1039/C7NR01604B</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -372,7 +372,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 13 Feb 2015</span><br>
                 <span><i><strong>J. Mater. Chem. C</strong></i>, 2015,<span style='padding-right:2px'></span><strong>3</strong>, 2717-2731</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C4TC02418D">http://dx.doi.org/10.1039/C4TC02418D</a></span>
+                <span><a href="https://doi.org/10.1039/C4TC02418D">https://doi.org/10.1039/C4TC02418D</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -431,7 +431,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 22 Sep 2014</span><br>
                 <span><i><strong>Nanoscale</strong></i>, 2015,<span style='padding-right:2px'></span><strong>7</strong>, 4598-4810</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C4NR01600A">http://dx.doi.org/10.1039/C4NR01600A</a></span>
+                <span><a href="https://doi.org/10.1039/C4NR01600A">https://doi.org/10.1039/C4NR01600A</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -489,7 +489,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 01 Dec 2015</span><br>
                 <span><i><strong>RSC Adv.</strong></i>, 2015,<span style='padding-right:2px'></span><strong>5</strong>, 107716-107770</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C5RA16478H">http://dx.doi.org/10.1039/C5RA16478H</a></span>
+                <span><a href="https://doi.org/10.1039/C5RA16478H">https://doi.org/10.1039/C5RA16478H</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -550,7 +550,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 07 Dec 2016</span><br>
                 <span><i><strong>Nanoscale</strong></i>, 2017,<span style='padding-right:2px'></span><strong>9</strong>, 965-993</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C6NR08220C">http://dx.doi.org/10.1039/C6NR08220C</a></span>
+                <span><a href="https://doi.org/10.1039/C6NR08220C">https://doi.org/10.1039/C6NR08220C</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -608,7 +608,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 22 Jun 2015</span><br>
                 <span><i><strong>RSC Adv.</strong></i>, 2015,<span style='padding-right:2px'></span><strong>5</strong>, 63985-64030</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C5RA08205F">http://dx.doi.org/10.1039/C5RA08205F</a></span>
+                <span><a href="https://doi.org/10.1039/C5RA08205F">https://doi.org/10.1039/C5RA08205F</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -656,7 +656,7 @@
 
             <div class="text--small">
                 <span><i><strong>J. Mater. Chem.</strong></i>, 1999,<span style='padding-right:2px'></span><strong>9</strong>, 1895-1904</span><br>
-                <span><a href="http://dx.doi.org/10.1039/A902652E">http://dx.doi.org/10.1039/A902652E</a></span>
+                <span><a href="https://doi.org/10.1039/A902652E">https://doi.org/10.1039/A902652E</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -718,7 +718,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 07 May 2014</span><br>
                 <span><i><strong>Chem. Soc. Rev.</strong></i>, 2014,<span style='padding-right:2px'></span><strong>43</strong>, 5513-5560</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C4CS00089G">http://dx.doi.org/10.1039/C4CS00089G</a></span>
+                <span><a href="https://doi.org/10.1039/C4CS00089G">https://doi.org/10.1039/C4CS00089G</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -779,7 +779,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 09 Mar 2018</span><br>
                 <span><i><strong>J. Mater. Chem. C</strong></i>, 2018,<span style='padding-right:2px'></span><strong>6</strong>, 3143-3181</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C7TC05271E">http://dx.doi.org/10.1039/C7TC05271E</a></span>
+                <span><a href="https://doi.org/10.1039/C7TC05271E">https://doi.org/10.1039/C7TC05271E</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -837,7 +837,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 04 Jun 2014</span><br>
                 <span><i><strong>J. Mater. Chem. C</strong></i>, 2014,<span style='padding-right:2px'></span><strong>2</strong>, 6436-6453</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C4TC00618F">http://dx.doi.org/10.1039/C4TC00618F</a></span>
+                <span><a href="https://doi.org/10.1039/C4TC00618F">https://doi.org/10.1039/C4TC00618F</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -895,7 +895,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 31 May 2016</span><br>
                 <span><i><strong>Nanoscale</strong></i>, 2016,<span style='padding-right:2px'></span><strong>8</strong>, 13131-13154</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C6NR03054H">http://dx.doi.org/10.1039/C6NR03054H</a></span>
+                <span><a href="https://doi.org/10.1039/C6NR03054H">https://doi.org/10.1039/C6NR03054H</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -956,7 +956,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 23 Apr 2014</span><br>
                 <span><i><strong>J. Mater. Chem. A</strong></i>, 2014,<span style='padding-right:2px'></span><strong>2</strong>, 10712-10738</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C4TA00716F">http://dx.doi.org/10.1039/C4TA00716F</a></span>
+                <span><a href="https://doi.org/10.1039/C4TA00716F">https://doi.org/10.1039/C4TA00716F</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -1014,7 +1014,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 29 Jun 2016</span><br>
                 <span><i><strong>J. Mater. Chem. C</strong></i>, 2016,<span style='padding-right:2px'></span><strong>4</strong>, 7156-7164</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C6TC01979J">http://dx.doi.org/10.1039/C6TC01979J</a></span>
+                <span><a href="https://doi.org/10.1039/C6TC01979J">https://doi.org/10.1039/C6TC01979J</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -1072,7 +1072,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 05 Sep 2016</span><br>
                 <span><i><strong>J. Mater. Chem. C</strong></i>, 2016,<span style='padding-right:2px'></span><strong>4</strong>, 9116-9142</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C6TC03230C">http://dx.doi.org/10.1039/C6TC03230C</a></span>
+                <span><a href="https://doi.org/10.1039/C6TC03230C">https://doi.org/10.1039/C6TC03230C</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -1130,7 +1130,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 25 Sep 2014</span><br>
                 <span><i><strong>J. Mater. Chem. C</strong></i>, 2014,<span style='padding-right:2px'></span><strong>2</strong>, 10232-10261</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C4TC01820F">http://dx.doi.org/10.1039/C4TC01820F</a></span>
+                <span><a href="https://doi.org/10.1039/C4TC01820F">https://doi.org/10.1039/C4TC01820F</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -1188,7 +1188,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 17 Jun 2011</span><br>
                 <span><i><strong>Chem. Soc. Rev.</strong></i>, 2011,<span style='padding-right:2px'></span><strong>40</strong>, 5406-5441</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C1CS15065K">http://dx.doi.org/10.1039/C1CS15065K</a></span>
+                <span><a href="https://doi.org/10.1039/C1CS15065K">https://doi.org/10.1039/C1CS15065K</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -1246,7 +1246,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 19 Mar 2013</span><br>
                 <span><i><strong>Chem. Soc. Rev.</strong></i>, 2013,<span style='padding-right:2px'></span><strong>42</strong>, 5184-5209</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C3CS35501B">http://dx.doi.org/10.1039/C3CS35501B</a></span>
+                <span><a href="https://doi.org/10.1039/C3CS35501B">https://doi.org/10.1039/C3CS35501B</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -1304,7 +1304,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 08 Jan 2010</span><br>
                 <span><i><strong>Analyst</strong></i>, 2010,<span style='padding-right:2px'></span><strong>135</strong>, 845-867</span><br>
-                <span><a href="http://dx.doi.org/10.1039/B916888E">http://dx.doi.org/10.1039/B916888E</a></span>
+                <span><a href="https://doi.org/10.1039/B916888E">https://doi.org/10.1039/B916888E</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -1362,7 +1362,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 17 Oct 2013</span><br>
                 <span><i><strong>J. Mater. Chem. C</strong></i>, 2014,<span style='padding-right:2px'></span><strong>2</strong>, 286-294</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C3TC31740D">http://dx.doi.org/10.1039/C3TC31740D</a></span>
+                <span><a href="https://doi.org/10.1039/C3TC31740D">https://doi.org/10.1039/C3TC31740D</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -1420,7 +1420,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 11 Jun 2014</span><br>
                 <span><i><strong>Analyst</strong></i>, 2014,<span style='padding-right:2px'></span><strong>139</strong>, 4661-4672</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C4AN00646A">http://dx.doi.org/10.1039/C4AN00646A</a></span>
+                <span><a href="https://doi.org/10.1039/C4AN00646A">https://doi.org/10.1039/C4AN00646A</a></span>
             </div>
 
         <div class="capsule__action--buttons">
@@ -1478,7 +1478,7 @@
             <div class="text--small">
                     <span class="block fixpadv--xs">The article was first published on 09 May 2012</span><br>
                 <span><i><strong>Chem. Soc. Rev.</strong></i>, 2012,<span style='padding-right:2px'></span><strong>41</strong>, 4560-4580</span><br>
-                <span><a href="http://dx.doi.org/10.1039/C2CS15335A">http://dx.doi.org/10.1039/C2CS15335A</a></span>
+                <span><a href="https://doi.org/10.1039/C2CS15335A">https://doi.org/10.1039/C2CS15335A</a></span>
             </div>
 
         <div class="capsule__action--buttons">

--- a/download-citation/springer.py
+++ b/download-citation/springer.py
@@ -61,7 +61,7 @@ def royal(article_urls):
         except:
             pass
         try:
-            citation_url = 'http://dx.doi.org/' + citation_doi
+            citation_url = 'https://doi.org/' + citation_doi
         except:
             pass
         try:

--- a/some/pa.py
+++ b/some/pa.py
@@ -110,7 +110,7 @@ def royal(url):
     citation_doi = bsop.find('meta', {'name':'citation_doi'}).attrs['content']
     PB = bsop.find('meta', {'name':'DC.publisher'}).attrs['content']
     M3 = citation_doi
-    citation_url = 'http://dx.doi.org/' + citation_doi
+    citation_url = 'https://doi.org/' + citation_doi
     citation_abstract = bsop.find('meta', {'name':'citation_abstract'}).attrs['content'].strip()
     SN = bsop.find('div', {'class':'article-nav__issue autopad--h'}).find('a').attrs['href'].split('=')[-1]
 

--- a/some/pa1.py
+++ b/some/pa1.py
@@ -60,7 +60,7 @@ def royal(article_urls):
         except:
             pass
         try:
-            citation_url = 'http://dx.doi.org/' + citation_doi
+            citation_url = 'https://doi.org/' + citation_doi
         except:
             pass
         try:

--- a/some/springer.py
+++ b/some/springer.py
@@ -61,7 +61,7 @@ def royal(article_urls):
         except:
             pass
         try:
-            citation_url = 'http://dx.doi.org/' + citation_doi
+            citation_url = 'https://doi.org/' + citation_doi
         except:
             pass
         try:


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

I'd simply like to suggest to update all static DOI links and the code that generates new DOI links accordingly.

Cheers!